### PR TITLE
tweaks to make initializing cucu in another repo simple

### DIFF
--- a/data/features/environment.py
+++ b/data/features/environment.py
@@ -1,1 +1,4 @@
-from cucu.environment import *
+import cucu
+
+# initialize cucu envirnoment hooks
+cucu.init(locals())

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,1 +1,4 @@
-from cucu.environment import *
+import cucu
+
+# initialize cucu envirnoment hooks
+cucu.init(locals())

--- a/src/cucu/__init__.py
+++ b/src/cucu/__init__.py
@@ -2,4 +2,5 @@
 __version__ = '0.1.0'
 
 # flake8: noqa
-from cucu.hooks import *
+# we only expose the exact hooks we want to the outside world here.
+from cucu.hooks import init, register_after_scenario_hook, run_steps

--- a/src/cucu/hooks.py
+++ b/src/cucu/hooks.py
@@ -1,4 +1,18 @@
+import importlib
+
 from cucu.config import CONFIG
+
+
+def init(locals):
+    """
+    initialize cucu internal environment hooks
+
+    Params:
+        locals - the locals() object from the environment.py file this is being
+                 called from since we have to be able to set the behave hooks
+                 at that exact module level.
+    """
+    locals.update(importlib.import_module('cucu.environment').__dict__)
 
 
 def register_after_scenario_hook(after_scenario_func):

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -84,7 +84,7 @@
                 </tr>
                 {% endif %}
             {% endif %}
-            {% if step['image'] is defined %}
+            {% if step['image'] is defined and step['result'] is defined %}
             <tr>
                 <td colspan="2"><img class="col-12 shadow p-3 mb-5 bg-white rounded" alt='{{ step_name }}' title='{{ step_name }}' src='{{ step["image"] }}'></img></td>
             </tr>


### PR DESCRIPTION
* basically provide a `cucu.init()` for use in othe repos instead of
  doing the confusing `from cucu.environment import *`

* fixed the reporting so we don't get screenshots for steps that never
  executed.