### PR TITLE
include all output in html test report

### DIFF
--- a/features/cli/report.feature
+++ b/features/cli/report.feature
@@ -50,6 +50,17 @@ Feature: Report
       And I should see the image with the alt text "And I click the button \"Google Search\""
       And I should see the image with the alt text "Then I should see the text \"Dog\""
 
+  Scenario: User can run a feature with mixed results and has all results reported correctly
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --results {CUCU_RESULTS_DIR}/mixed-results" and save exit code to "EXIT_CODE"
+     Then I should see "{EXIT_CODE}" is equal to "1"
+     When I run the command "cucu report {CUCU_RESULTS_DIR}/mixed-results --output {CUCU_RESULTS_DIR}/mixed-results-report" and save exit code to "EXIT_CODE"
+     Then I should see "{EXIT_CODE}" is equal to "0"
+     When I start a webserver on port "40000" at directory "{CUCU_RESULTS_DIR}/mixed-results-report/"
+      And I open a browser at the url "http://{HOST_ADDRESS}:40000/index.html"
+      And I click the button "Feature: Feature with mixed results" 
+      And I click the button "Scenario: Scenario that fails"
+     Then I should see the text "RuntimeError: step fails on purpose"
+
   @disabled @needs-work
   Scenario: User can run a scenario with console logs and see those logs linked in the report
     Given I run the command "cucu run data/features/scenario_with_console_logs.feature --results {CUCU_RESULTS_DIR}/console-log-reporting" and save stdout to "STDOUT", exit code to "EXIT_CODE"

--- a/src/cucu/hooks.py
+++ b/src/cucu/hooks.py
@@ -91,7 +91,7 @@ def run_steps(context, steps_text):
                         message += 'Traceback (of failed substep):\n'
                         message += ''.join(traceback.format_tb(step.exc_traceback))
 
-                    assert False, message
+                    raise RuntimeError(message)
 
             # -- FINALLY: Restore original context data for current step.
             context.table = original_table

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -37,16 +37,16 @@
             {% endif %}
             <tr>
                 {% if step['result'] is not defined %}
-                    <td><pre style="display: inline; color: blue;">{{ step_prefix }}{{ step_name }}</pre></td>
+                    <td><pre style="display: inline; color: blue">{{ step_prefix }}{{ step['keyword'].rjust(6, ' ') }}</pre><pre style="color: blue; display: inline"> {{ step['name'] }}</pre></td>
                     <td></td>
                 {% elif step['result']['status'] == 'passed' %}
                     <td><pre style="display: inline; color: green">{{ step_prefix }}{{ step['keyword'].rjust(6, ' ') }}</pre><pre style="display: inline"> {{ step['name'] }}</pre></td>
                     <td><pre style="display: inline; color: gray;"># {{ '{:.3f}'.format(step['result']['duration']) }}s</pre></td>
                 {% elif step['result']['status'] == 'failed' %}
-                    <td><pre style="display: inline; color: red">{{ step_prefix }}{{ step_name }}</pre></td>
+                    <td><pre style="display: inline; color: red">{{ step_prefix }}{{ step['keyword'].rjust(6, ' ') }}</pre><pre style="color: red; display: inline"> {{ step['name'] }}</pre></td>
                     <td><pre style="display: inline; color: gray;"># {{ '{:.3f}'.format(step['result']['duration']) }}s</pre></td>
                 {% elif step['result']['status'] == 'skipped' %}
-                    <td><pre style="display: inline; color: blue">{{ step_prefix }}{{ step_name }}</pre></td>
+                    <td><pre style="display: inline; color: blue">{{ step_prefix }}{{ step['keyword'].rjust(6, ' ') }}</pre><pre style="color: blue; display: inline"> {{ step['name'] }}</pre></td>
                 {% endif %}
             </tr>
             {% if step['text'] %}
@@ -86,6 +86,15 @@
                     {% endfor %}
                 </tr>
                 {% endif %}
+
+                {% if step['result']['error_message'] %}
+                    {% for line in step['result']['error_message'] %}
+                    <tr>
+                        <td colspan="2" style="margin: 0"><pre style="color: gray; margin: 0">{{ line }}</pre></td>
+                    </tr>
+                    {% endfor %}
+                {% endif %}
+
             {% endif %}
             {% if step['image'] is defined and step['result'] is defined %}
             <tr>


### PR DESCRIPTION
* fixes the reporting to include the missing stacktraces and I've also
  fixed up the indentation/alignment of the skipped/failed steps