### PR TITLE
hide sensitive secrets in cucu outputs

### DIFF
--- a/data/features/scenario_with_console_logs.feature
+++ b/data/features/scenario_with_console_logs.feature
@@ -4,7 +4,7 @@ Feature: Feature with console logs
     Given I start a webserver on port "40000" at directory "data/www"
      Then I open a browser at the url "http://{HOST_ADDRESS}:40000/console_logging.html"
       And I should see the text "Console Logging!"
-  
+
   Scenario: Scenario without console logs
     Given I start a webserver on port "40000" at directory "data/www"
      Then I open a browser at the url "http://{HOST_ADDRESS}:40000/buttons.html"

--- a/features/cli/report.feature
+++ b/features/cli/report.feature
@@ -57,7 +57,7 @@ Feature: Report
      Then I should see "{EXIT_CODE}" is equal to "0"
      When I start a webserver on port "40000" at directory "{CUCU_RESULTS_DIR}/mixed-results-report/"
       And I open a browser at the url "http://{HOST_ADDRESS}:40000/index.html"
-      And I click the button "Feature: Feature with mixed results" 
+      And I click the button "Feature: Feature with mixed results"
       And I click the button "Scenario: Scenario that fails"
      Then I should see the text "RuntimeError: step fails on purpose"
 
@@ -73,7 +73,7 @@ Feature: Report
       And I click the button "Scenario: Scenario with console logs"
       And I click the button "Logs"
      Then I should see the button "browser_console.log"
-     When I click the button "browser_console.log" 
+     When I click the button "browser_console.log"
      Then I wait to see the text "this is a regular log"
       And I should see the text "this is an error log"
       And I should see the text "this is a debug log"

--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -1,0 +1,60 @@
+Feature: Secrets
+  As a developer I want the user to have control over what secrets are printed
+  in logs and which are masked.
+
+  Scenario: User can run a test while hiding secrets using their cucurc.yml file
+    Given I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/environment.py" with the following:
+      """
+      import cucu
+      cucu.init_environment()
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/steps/__init__.py" with the following:
+      """
+      import cucu
+      cucu.init_steps()
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/cucurc.yml" with the following:
+      """
+      CUCU_SECRETS: MY_SECRET
+      MY_SECRET: 'super secret'
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/features/feature_that_spills_the_beans.feature" with the following:
+      """
+      Feature: Feature that spills the beans
+
+        Scenario: This scenario prints some secrets to the logs
+         Given I echo "the current user is {{USER}}"
+           And I echo "{{MY_SECRET}}"
+           And I echo "your home directory is at {{HOME}}"
+      """
+      When I run the command "cucu run {CUCU_RESULTS_DIR}/features_with_secrets --results={CUCU_RESULTS_DIR}/features_with_secrets_results" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
+      Then I should see "{EXIT_CODE}" is equal to "0"
+       And I should see "{STDOUT}" does not contain "super secret"
+
+  Scenario: User can run a test while hiding secrets identified by the command line option
+    Given I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/environment.py" with the following:
+      """
+      import cucu
+      cucu.init_environment()
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/steps/__init__.py" with the following:
+      """
+      import cucu
+      cucu.init_steps()
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/cucurc.yml" with the following:
+      """
+      MY_SECRET: 'super secret'
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/features/feature_that_spills_the_beans.feature" with the following:
+      """
+      Feature: Feature that spills the beans
+
+        Scenario: This scenario prints some secrets to the logs
+         Given I echo "the current user is {{USER}}"
+           And I echo "{{MY_SECRET}}"
+           And I echo "your home directory is at {{HOME}}"
+      """
+      When I run the command "cucu run {CUCU_RESULTS_DIR}/features_with_secrets --secrets MY_SECRET --results={CUCU_RESULTS_DIR}/features_with_secrets_results" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
+      Then I should see "{EXIT_CODE}" is equal to "0"
+       And I should see "{STDOUT}" does not contain "super secret"

--- a/src/cucu/config.py
+++ b/src/cucu/config.py
@@ -112,6 +112,10 @@ def get_local_address():
 CONFIG['HOST_ADDRESS'] = get_local_address()
 CONFIG['CWD'] = os.getcwd()
 
+# coma separated list of variables that we should hide if their values are to
+# be printed to the console
+CONFIG['CUCU_SECRETS'] = ''
+
 CONFIG['CUCU_STEP_WAIT_TIMEOUT_MS'] = 20000  # default of 20s to wait
 CONFIG['CUCU_STEP_RETRY_AFTER_MS'] = 500     # default of 500ms to wait between retries
 CONFIG['CUCU_KEEP_BROWSER_ALIVE'] = False

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -3,10 +3,8 @@ import os
 import sys
 import uuid
 
-from cucu import behave_tweaks, config, logger
+from cucu import config, logger
 from cucu.config import CONFIG
-
-behave_tweaks.init_step_hooks(sys.stdout, sys.stderr)
 
 
 def escape_filename(string):
@@ -91,7 +89,6 @@ def after_step(context, step):
     # grab the captured output during the step run and reset the wrappers
     step.stdout = sys.stdout.captured()
     step.stderr = sys.stderr.captured()
-    behave_tweaks.uninit_output_streams()
 
     if context.browser is not None and not context.substep_increment:
         step_name = escape_filename(step.name)

--- a/src/cucu/steps/variable_steps.py
+++ b/src/cucu/steps/variable_steps.py
@@ -21,6 +21,18 @@ def should_see_is_equal(_, this, that):
         raise RuntimeError(f'{this} is not equal to {that}')
 
 
+@step('I should see "{this}" contains "{that}"')
+def should_see_it_contains(_, this, that):
+    if that not in this:
+        raise RuntimeError(f'{this} does not contain {that}')
+
+
+@step('I should see "{this}" does not contain "{that}"')
+def should_see_it_doest_not_contain(_, this, that):
+    if that in this:
+        raise RuntimeError(f'{this} contain {that}')
+
+
 @step('I should see "{this}" is equal to the following')
 def should_see_is_equal_to_the_following(context, this):
     that = context.text


### PR DESCRIPTION
* this should allow any user of cucu to identify a list of variable
  names that contain secret values that we want to hide in the various
  outputs of cucu