### PR TITLE
add flag to generate report on `cucu run`

### DIFF
--- a/data/features/feature_with_passing_scenario.feature
+++ b/data/features/feature_with_passing_scenario.feature
@@ -1,0 +1,4 @@
+Feature: Feature with passing scenario
+
+  Scenario: Just a scenario that passes
+    Given I echo "nothing to see here"

--- a/features/cli/run.feature
+++ b/features/cli/run.feature
@@ -91,3 +91,21 @@ Feature: Run
       [\s\S]*
       """
       And I should see "{STDERR}" is empty
+
+  Scenario: User can run a passing scenario and generate a report
+    Given I run the command "cucu run data/features/feature_with_passing_scenario.feature --results {CUCU_RESULTS_DIR}/run_with_report_results --generate-report --report {CUCU_RESULTS_DIR}/run_with_report_report" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
+     Then I should see "{EXIT_CODE}" is equal to "0"
+     When I start a webserver on port "40000" at directory "{CUCU_RESULTS_DIR}/run_with_report_report/"
+      And I open a browser at the url "http://{HOST_ADDRESS}:40000/index.html"
+     Then I should see the link "Feature: Feature with passing scenario"
+     When I click the link "Feature: Feature with passing scenario"
+     Then I should see the link "Scenario: Just a scenario that passes"
+
+  Scenario: User can run a failing scenario and generate a report
+    Given I run the command "cucu run data/features/feature_with_failing_scenario.feature --results {CUCU_RESULTS_DIR}/run_with_report_results --generate-report --report {CUCU_RESULTS_DIR}/run_with_report_report" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
+     Then I should see "{EXIT_CODE}" is equal to "1"
+     When I start a webserver on port "40000" at directory "{CUCU_RESULTS_DIR}/run_with_report_report/"
+      And I open a browser at the url "http://{HOST_ADDRESS}:40000/index.html"
+     Then I should see the link "Feature: Feature with failing scenario"
+     When I click the link "Feature: Feature with failing scenario"
+     Then I should see the link "Scenario: Just a scenario that fails"

--- a/src/cucu/steps/filesystem_steps.py
+++ b/src/cucu/steps/filesystem_steps.py
@@ -20,6 +20,12 @@ def append_to_file_the_following(context, filepath):
         output.write(bytes(context.text, "utf8"))
 
 
+@step('I should see the file at "{filepath}"')
+def should_see_file(context, filepath):
+    if not (os.path.exists(filepath) and os.path.isfile(filepath)):
+        raise RuntimeError(f"unable to see file at {filepath}")
+
+
 @step('I should see the file at "{filepath}" has the following')
 def should_see_file_with_the_following(context, filepath):
     with open(filepath, "rb") as input:


### PR DESCRIPTION
* with this you can now specify `--generate-report` and independently of having
  failed or passed the test run cucu will generate the `cucu report`