### PR TITLE
fix bug with `cucu steps` when a test has undefined steps

### DIFF
--- a/features/cli/steps.feature
+++ b/features/cli/steps.feature
@@ -1,0 +1,56 @@
+Feature: Steps
+  As a developer I want the user to be able to use the `cucu steps` command
+  without any issues.
+
+  Scenario: User can get the current set of available cucu steps
+    Given I run the command "cucu steps" and save stdout to "STDOUT", exit code to "EXIT_CODE"
+     Then I should see "{EXIT_CODE}" is equal to "0"
+      # just validate some built-in steps show up
+      And I should see "{STDOUT}" contains the following:
+      """
+      I open a browser at the url "{{url}}"
+      """
+      And I should see "{STDOUT}" contains the following:
+      """
+      I start a webserver on port "{{port}}" at directory "{{directory}}"
+      """
+
+  Scenario: User can use `cucu steps` even if there are undefined steps
+    Given I create a file at "{CUCU_RESULTS_DIR}/undefined_steps/features/environment.py" with the following:
+      """
+      import cucu
+      cucu.init_environment()
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/undefined_steps/features/steps/__init__.py" with the following:
+      """
+      import cucu
+      cucu.init_steps()
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/undefined_steps/features/cucurc.yml" with the following:
+      """
+      CUCU_SECRETS: MY_SECRET
+      MY_SECRET: 'super secret'
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/undefined_steps/features/feature_that_spills_the_beans.feature" with the following:
+      """
+      Feature: Feature with an undefined step
+
+        Scenario: This scenario with an undefined step
+          Given I attempt to use an undefined step
+      """
+     When I run the following script and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
+      """
+      #!{SHELL}
+      pushd {CUCU_RESULTS_DIR}/undefined_steps
+      cucu steps
+      """
+     Then I should see "{EXIT_CODE}" is equal to "0"
+      # just validate some built-in steps show up
+      And I should see "{STDOUT}" contains the following:
+      """
+      I open a browser at the url "{{url}}"
+      """
+      And I should see "{STDOUT}" contains the following:
+      """
+      I start a webserver on port "{{port}}" at directory "{{directory}}"
+      """

--- a/src/cucu/cli/steps.py
+++ b/src/cucu/cli/steps.py
@@ -36,10 +36,11 @@ def load_cucu_steps():
         an array of hashmaps
     """
     steps_cache = {}
-    steps_doc_output = subprocess.check_output(
-        ["behave", "--dry-run", "--no-summary", "--format", "steps.doc"]
+    process = subprocess.run(
+        ["behave", "--dry-run", "--no-summary", "--format", "steps.doc"],
+        capture_output=True,
     )
-    steps_doc_output = steps_doc_output.decode("utf8")
+    steps_doc_output = process.stdout.decode("utf8")
 
     for cucu_step in steps_doc_output.split("\n\n"):
         # each blank line is a '\n\n' which is a split between two step

--- a/src/cucu/steps/variable_steps.py
+++ b/src/cucu/steps/variable_steps.py
@@ -33,6 +33,12 @@ def should_see_it_contains(_, this, that):
         raise RuntimeError(f"{this} does not contain {that}")
 
 
+@step('I should see "{this}" contains the following')
+def should_see_it_contains(ctx, this):
+    if ctx.text not in this:
+        raise RuntimeError(f"{this} does not contain {ctx.text}")
+
+
 @step('I should see "{this}" does not contain "{that}"')
 def should_see_it_doest_not_contain(_, this, that):
     if that in this:


### PR DESCRIPTION
* quick fix for `cucu steps` bug when there were undefined steps present
  the whole thing would throw an exception and never print any available
  steps