### PR TITLE
Strip whitespace from command arguments

### DIFF
--- a/src/cucu/steps/command_steps.py
+++ b/src/cucu/steps/command_steps.py
@@ -7,7 +7,7 @@ from cucu import config, logger
 
 
 def run_command(command, stdout_var=None, stderr_var=None, exit_code_var=None):
-    args = shlex.split(command)
+    args = [a.strip() for a in shlex.split(command)]
     process = subprocess.run(args, capture_output=True)
 
     if exit_code_var:


### PR DESCRIPTION
When shlex tries to parse multi-line scripts, it leaves in newlines. However, `subprocess` chokes on these newlines. If we want to be able to process multiline scripts (and we do, that's how the cURL command to hit Model APIs is presented), then we need to remove the newlines, first.