### PR TITLE
Add backup method of clearing inputs

### DIFF
--- a/src/cucu/steps/input_steps.py
+++ b/src/cucu/steps/input_steps.py
@@ -74,15 +74,8 @@ def find_n_clear(ctx, name, index=0):
     input_ = find_input(ctx, name, index=index)
     input_.clear()
     # .clear() doesn't do it 100% of the time, so take out insurance
-    maximum_attempts = 5
-    attempts = 0
     current_value = input_.get_attribute("value")
-    while current_value != "" and attempts < maximum_attempts:
-        input_.send_keys(Keys.BACKSPACE * len(current_value))
-        current_value = input_.get_attribute("value")
-
-    if not attempts < maximum_attempts:
-        raise RuntimeError(f"input '{name}' was not cleared after {maximum_attempts} attempts")
+    input_.send_keys(Keys.BACKSPACE * len(current_value))
 
 
 def assert_input_value(ctx, name, value, index=0):


### PR DESCRIPTION
For some reason, there was as input in Domino that `.clear` just, like stopped working for? I swear `.clear` was working, and now it's not, so I figured out another way to clear an input, because I need to get it clear one way or another.