### PR TITLE
fix bug when using `nth` type outside of cucu

### DIFF
--- a/data/features/feature_with_scenario_using_nth_type.feature
+++ b/data/features/feature_with_scenario_using_nth_type.feature
@@ -1,0 +1,4 @@
+Feature: Feature with scenario using nth type
+
+  Scenario: That uses a step using the nth type
+    Given I use a step with "1st" usage

--- a/data/features/steps/cucu_steps.py
+++ b/data/features/steps/cucu_steps.py
@@ -73,3 +73,8 @@ def search_for_on_google(context, query):
      And I click the button "Google Search"
     """,
     )
+
+
+@step('I use a step with "{nth:nth}" usage')
+def uses_nth_g(ctx, nth):
+    print("just a step that nth behave argument type")

--- a/features/cli/internals.feature
+++ b/features/cli/internals.feature
@@ -11,3 +11,7 @@ Feature: Internals
        .*File ".*\/src\/cucu\/steps\/text_steps.py", line 25, in \<module\>
        [\s\S]*
        """
+
+  Scenario: User can run a feature file that uses cucu behave types
+    Given I run the command "cucu run data/features/feature_with_scenario_using_nth_type.feature --results={CUCU_RESULTS_DIR}/with_nth_results" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
+      Then I should see "{EXIT_CODE}" is equal to "0"

--- a/src/cucu/hooks.py
+++ b/src/cucu/hooks.py
@@ -17,12 +17,12 @@ def init_steps():
 
     path = [os.path.dirname(f_globals["__file__"])]
 
+    importlib.import_module("cucu.steps")
+
     for loader, module_name, is_pkg in pkgutil.walk_packages(path):
         __all__.append(module_name)
         _module = loader.find_module(module_name).load_module(module_name)
         f_globals[module_name] = _module
-
-    f_locals.update(importlib.import_module("cucu.steps").__dict__)
 
 
 def init_environment():


### PR DESCRIPTION
* basically the order by which we were loading the imports wasn't
  correct and there was also no need to update the `f_locals` of the
  calling space as that was a little "nasty" and we were polluting the
  calling modules space.