### PR TITLE
handle chromedriver autoinstaller better

### DIFF
--- a/features/cli/run.feature
+++ b/features/cli/run.feature
@@ -63,3 +63,8 @@ Feature: Run
       1 step passed, 0 failed, 5 skipped, 0 undefined
       [\s\S]*
       """
+
+  Scenario: User can run a simple test within a reasonable amount of time
+    Given I run the command "cucu run data/features/echo.feature" and save stdout to "STDOUT", exit code to "EXIT_CODE"
+     Then I should see the previous step took less than "5" seconds
+     Then I should see "{EXIT_CODE}" is equal to "0"

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -24,13 +24,21 @@ def init():
     """
     initialize any selenium specific needs
     """
+    utils = chromedriver_autoinstaller.utils
+    chromedriver_autoinstaller_path = utils.get_chromedriver_path()
+    chromedriver_filename = utils.get_chromedriver_filename()
+    chrome_version = utils.get_chrome_version()
+    chrome_major_version = utils.get_major_version(chrome_version)
+    chromedriver_path = os.path.join(
+        chromedriver_autoinstaller_path,
+        chrome_major_version,
+        chromedriver_filename,
+    )
 
-    try:
-        # auto install chromedriver if not present
+    # auto install chromedriver if not present
+    if not os.path.exists(chromedriver_path):
         with DisableLogger():
             chromedriver_autoinstaller.install()
-    except Exception as exception:
-        logger.warn(f"unable to auto install chromedriver: {exception}")
 
 
 class Selenium(Browser):

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -157,7 +157,8 @@ def run(
     if selenium_remote_url is not None:
         CONFIG["CUCU_SELENIUM_REMOTE_URL"] = selenium_remote_url
 
-    selenium.init()
+    if CONFIG["CUCU_SELENIUM_REMOTE_URL"] is None:
+        selenium.init()
 
     try:
         if workers is None or workers == 1:


### PR DESCRIPTION
* we had a few snafus trying to install chromedriver on our CI and then
  logging warnings when we couldn't instead of handling it more
  elegantly and on top of that I ran into an issue locally where it
  keeps trying to install the driver on every run which is slowing down
  individual feature file runs by several seconds.