### PR TITLE
setting the global timeout in a different place

### DIFF
--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -24,6 +24,7 @@ from tabulate import tabulate
 # socket connect/read call
 timeout = float(CONFIG["CUCU_SOCKET_DEFAULT_TIMEOUT_S"])
 socket.setdefaulttimeout(timeout)
+socket._GLOBAL_DEFAULT_TIMEOUT = timeout
 
 # will start coverage tracking once COVERAGE_PROCESS_START is set
 coverage.process_startup()


### PR DESCRIPTION
* python 2 vs 3 left this _GLOBAL_DEFAULT_TIMEOUT around and seeing as
  some of the webdriver calls can get stuck on a read this is an attempt
  to see that setting this makes those reads timeout instead of gettin
  stuck in CI.