### PR TITLE
fix chromedriver-autoinstall

### DIFF
--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -24,7 +24,6 @@ from tabulate import tabulate
 # socket connect/read call
 timeout = float(CONFIG["CUCU_SOCKET_DEFAULT_TIMEOUT_S"])
 socket.setdefaulttimeout(timeout)
-socket._GLOBAL_DEFAULT_TIMEOUT = timeout
 
 # will start coverage tracking once COVERAGE_PROCESS_START is set
 coverage.process_startup()


### PR DESCRIPTION
* unbreak socket.create_connection()
![image](https://user-images.githubusercontent.com/95940265/167715456-ec3cf4a1-ae98-4e02-ab2b-d0ecfb1d3eb6.png)
sockets creates this `object` and if you override then what should be an Int becomes an Object instead and you get the error 

```
File "/home/circleci/.pyenv/versions/3.9.7/lib/python3.9/site-packages/urllib3/util/connection.py", line 82, in create_connection
    sock.settimeout(timeout)
TypeError: an integer is required (got type object)
```