### PR TITLE
report underlying `cucu lint` erorrs when loading broken steps

### DIFF
--- a/features/cli/lint.feature
+++ b/features/cli/lint.feature
@@ -19,27 +19,13 @@ Feature: Lint
       """
      When I run the command "cucu lint {CUCU_RESULTS_DIR}/undefined_step_lint/undefined_step_feature.feature" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
      Then I should see "{EXIT_CODE}" is equal to "1"
-      And I should see "{STDOUT}" is equal to the following:
+      And I should see "{STDOUT}" contains the following:
       """
-      results/undefined_step_lint/undefined_step_feature.feature:4: E undefined step "I use an undefined step"
-
+      You can implement step definitions for undefined steps with these snippets:
       """
-      And I should see "{STDERR}" is equal to the following:
+      And I should see "{STDERR}" contains the following:
       """
-      Error: linting errors found, but not fixed, see above for details
-
-      """
-     When I run the command "cucu lint --fix {CUCU_RESULTS_DIR}/undefined_step_lint/undefined_step_feature.feature" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
-     Then I should see "{EXIT_CODE}" is equal to "1"
-      And I should see "{STDOUT}" is equal to the following:
-      """
-      results/undefined_step_lint/undefined_step_feature.feature:4: E undefined step "I use an undefined step" ✗ (must be fixed manually)
-
-      """
-      And I should see "{STDERR}" is equal to the following:
-      """
-      Error: linting errors found, but not fixed, see above for details
-
+      RuntimeError: error loading steps, see above for details
       """
 
   Scenario: User can find and fix indentation violations

--- a/src/cucu/cli/steps.py
+++ b/src/cucu/cli/steps.py
@@ -35,7 +35,6 @@ def load_cucu_steps(filepath=None):
     process = subprocess.run(args, capture_output=True)
 
     if process.returncode != 0:
-        print(process.stdout.decode("utf8"))
         print(process.stderr.decode("utf8"))
         raise RuntimeError("error loading steps, see above for details")
 


### PR DESCRIPTION
* this fixes the issue and reports clearly what went wrong when
  attempting to parse the available steps so linting could do its job
  correctly.