### PR TITLE
rework output handling to get cucu.debug.log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,6 @@ commands:
           name: run unit tests
           command: poetry run coverage run -m pytest --junit-xml=results/unit-tests.xml
 
-  tar_up_results_and_report: &tar_up_results_and_report
-    steps:
-      - run:
-          name: tar up results and report
-          command: tar cvfz results.tgz results && tar cvfz report.tgz report
-
   code_coverage_check: &code_coverage_check
     steps:
       - run:
@@ -143,8 +137,12 @@ jobs:
       - run_functional_tests:
           browser: "<< parameters.browser >>"
       - run_unit_tests
-      - tar_up_results_and_report
       - code_coverage_check
+
+      - run:
+          name: tar up results and report
+          command: tar cvfz results.tgz results && tar cvfz report.tgz report
+          when: always
 
       - store_artifacts:
           path: results.tgz

--- a/features/cli/report.feature
+++ b/features/cli/report.feature
@@ -96,6 +96,7 @@ Feature: Report
      Then I should see the button "Given I attempt to use an undefined step"
 
   @workaround @QE-7075
+  @disabled
   Scenario: User can run a scenario with console logs and see those logs linked in the report
     Given I skip this scenario if the current browser is not "chrome"
      When I run the command "cucu run data/features/scenario_with_console_logs.feature --results {CUCU_RESULTS_DIR}/console-log-reporting" and save stdout to "STDOUT", exit code to "EXIT_CODE"

--- a/features/cli/report.feature
+++ b/features/cli/report.feature
@@ -95,9 +95,10 @@ Feature: Report
       And I click the button "Scenario that has an undefined step"
      Then I should see the button "Given I attempt to use an undefined step"
 
-  @disabled @needs-work
+  @workaround @QE-7075
   Scenario: User can run a scenario with console logs and see those logs linked in the report
-    Given I run the command "cucu run data/features/scenario_with_console_logs.feature --results {CUCU_RESULTS_DIR}/console-log-reporting" and save stdout to "STDOUT", exit code to "EXIT_CODE"
+    Given I skip this scenario if the current browser is not "chrome"
+     When I run the command "cucu run data/features/scenario_with_console_logs.feature --results {CUCU_RESULTS_DIR}/console-log-reporting" and save stdout to "STDOUT", exit code to "EXIT_CODE"
      Then I should see "{EXIT_CODE}" is equal to "0"
      When I run the command "cucu report {CUCU_RESULTS_DIR}/console-log-reporting --output {CUCU_RESULTS_DIR}/console-log-reporting-report" and save exit code to "EXIT_CODE"
      Then I should see "{EXIT_CODE}" is equal to "0"
@@ -112,3 +113,16 @@ Feature: Report
       And I should see the text "this is an error log"
       And I should see the text "this is a debug log"
       And I should see the text "this is a warn log"
+
+  Scenario: User can run a scenario without debug logging on the console but still found the cucu.debug.log in the report
+    Given I run the command "cucu run  data/features/feature_with_passing_scenario_with_web.feature --results {CUCU_RESULTS_DIR}/cucu_debug_results --generate-report --report {CUCU_RESULTS_DIR}/cucu_debug_report" and save stdout to "STDOUT" and expect exit code "0"
+     When I start a webserver at directory "{CUCU_RESULTS_DIR}/cucu_debug_report" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
+      And I click the link "Feature with passing scenario with web"
+     Then I should not see the text "DEBUG executing page check \"wait for document.readyState\""
+      And I should not see the text "DEBUG executing page check \"broken image checker\""
+      And I click the button "Just a scenario that opens a web page"
+     When I click the button "Logs"
+      And I click the button "cucu.debug.console.log"
+     Then I wait to see the text "DEBUG executing page check \"wait for document.readyState\""
+      And I wait to see the text "DEBUG executing page check \"broken image checker\""

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -134,3 +134,14 @@ Feature: Run outputs
       [\s\S]*
       """
       And I should see "{STDERR}" is empty
+
+  Scenario: User gets JUnit XML results file as expected
+    Given I run the command "cucu run data/features/echo.feature --results {CUCU_RESULTS_DIR}/validate_junit_xml_results" and save stdout to "STDOUT", exit code to "EXIT_CODE"
+     Then I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Echo.xml"
+      And I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Echo.xml" matches the following:
+      """
+      <testsuite name="Echo" tests="0" errors="0" failures="0" skipped="0" timestamp=".*">
+       <testcase classname="Echo" name="Echo an environment variable" status="passed" time=".*">
+       </testcase>
+      </testsuite>
+      """

--- a/features/cli/run_with_junit.feature
+++ b/features/cli/run_with_junit.feature
@@ -5,10 +5,10 @@ Feature: Run with JUnit
   Scenario: User gets the JUnit XML files in the default location
     Given I run the command "cucu run data/features/echo.feature --results {CUCU_RESULTS_DIR}/run_with_default_junit_results --generate-report --report {CUCU_RESULTS_DIR}/run_with_default_junit_report" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
      Then I should see "{EXIT_CODE}" is equal to "0"
-      And I should see the file at "{CUCU_RESULTS_DIR}/run_with_default_junit_results/TESTS-echo.xml"
+      And I should see the file at "{CUCU_RESULTS_DIR}/run_with_default_junit_results/TESTS-Echo.xml"
 
   Scenario: User gets the JUnit XML files in the custom location
     Given I run the command "cucu run data/features/echo.feature --junit {CUCU_RESULTS_DIR}/junit_files --results {CUCU_RESULTS_DIR}/run_with_custom_junit_results --generate-report --report {CUCU_RESULTS_DIR}/run_with_custom_junit_report" and save stdout to "STDOUT", stderr to "STDERR", exit code to "EXIT_CODE"
      Then I should see "{EXIT_CODE}" is equal to "0"
-      And I should not see the file at "{CUCU_RESULTS_DIR}/run_with_custom_junit_results/TESTS-echo.xml"
-      And I should see the file at "{CUCU_RESULTS_DIR}/junit_files/TESTS-echo.xml"
+      And I should not see the file at "{CUCU_RESULTS_DIR}/run_with_custom_junit_results/TESTS-Echo.xml"
+      And I should see the file at "{CUCU_RESULTS_DIR}/junit_files/TESTS-Echo.xml"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,16 @@
 [[package]]
+name = "ansi2html"
+version = "1.7.0"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "setuptools-scm", "sphinx-rtd-theme"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "appnope"
 version = "0.1.3"
 description = "Disable App Nap on macOS >= 10.9"
@@ -955,9 +967,13 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "2ffb40e373e76787567737b1f9a382ac16ded6ebdb531900225053d8333cd6a9"
+content-hash = "c52b338b60b3de85d36f1a07b6a6f49967122daa79a0c8ed537929d88a56a695"
 
 [metadata.files]
+ansi2html = [
+    {file = "ansi2html-1.7.0-py3-none-any.whl", hash = "sha256:50517716d2e54f4167dadcec583fc7339e3684e4ff50a5f3d516fc8b54ce5875"},
+    {file = "ansi2html-1.7.0.tar.gz", hash = "sha256:69316be8c68ac91c5582d397c2890e69c993cc7cda52062ac7e45fcb660d8edc"},
+]
 appnope = [
     {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,6 +70,21 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.11.1"
+description = "Screen-scraping library"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "behave"
 version = "1.2.6"
 description = "behave is behaviour-driven development, Python style"
@@ -758,6 +773,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "soupsieve"
+version = "2.3.2.post1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "stack-data"
 version = "0.2.0"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -932,7 +955,7 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "cb62f3abb78d719352a0e535e3ec2add3cf6d53c9ad13d07c118a65cf19e4eb2"
+content-hash = "2ffb40e373e76787567737b1f9a382ac16ded6ebdb531900225053d8333cd6a9"
 
 [metadata.files]
 appnope = [
@@ -962,6 +985,10 @@ attrs = [
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
+    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
 behave = [
     {file = "behave-1.2.6-py2.py3-none-any.whl", hash = "sha256:ebda1a6c9e5bfe95c5f9f0a2794e01c7098b3dde86c10a95d8621c5907ff6f1c"},
@@ -1388,6 +1415,10 @@ sniffio = [
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+soupsieve = [
+    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
+    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
 stack-data = [
     {file = "stack_data-0.2.0-py3-none-any.whl", hash = "sha256:999762f9c3132308789affa03e9271bbbe947bf78311851f4d485d8402ed858e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ ipdb = "^0.13.9"
 geckodriver-autoinstaller = "^0.1.0"
 requests = "^2.27.1"
 beautifulsoup4 = "^4.11.1"
+ansi2html = "^1.7.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ tabulate = "^0.8.9"
 ipdb = "^0.13.9"
 geckodriver-autoinstaller = "^0.1.0"
 requests = "^2.27.1"
+beautifulsoup4 = "^4.11.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.3"

--- a/src/cucu/__init__.py
+++ b/src/cucu/__init__.py
@@ -7,9 +7,6 @@ from cucu import behave_tweaks
 # intercept the stdout/stderr so we can do things such as hiding secrets in logs
 behave_tweaks.init_step_hooks(sys.stdout, sys.stderr)
 
-sys.stdout = behave_tweaks.CucuStream(sys.stdout)
-sys.stderr = behave_tweaks.CucuStream(sys.stderr)
-
 from cucu.hooks import (
     init_global_hook_variables,
     init_scenario_hook_variables,

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -223,6 +223,9 @@ def run(
     # need to set this before initializing any browsers below
     os.environ["CUCU_BROWSER"] = browser.lower()
 
+    if CONFIG["CUCU_SELENIUM_REMOTE_URL"] is None:
+        selenium.init()
+
     if junit is None:
         junit = results
 

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -74,6 +74,25 @@ def before_scenario(ctx, scenario):
         CONFIG["SCENARIO_DOWNLOADS_DIR"] = ctx.scenario_downloads_dir
         os.makedirs(ctx.scenario_downloads_dir, exist_ok=True)
 
+        ctx.scenario_logs_dir = os.path.join(ctx.scenario_dir, "logs")
+        CONFIG["SCENARIO_LOGS_DIR"] = ctx.scenario_logs_dir
+        os.makedirs(ctx.scenario_logs_dir, exist_ok=True)
+
+        cucu_debug_filepath = os.path.join(
+            ctx.scenario_logs_dir, "cucu.debug.console.log"
+        )
+        ctx.scenario_debug_log_file = open(
+            cucu_debug_filepath, "w", encoding=sys.stdout.encoding
+        )
+
+        # redirect stdout, stderr and setup a logger at debug level to fill
+        # the scenario cucu.debug.log file which makes it possible to have
+        # debug logging for every single scenario run without polluting the
+        # console logs at runtime.
+        sys.stdout.set_other_stream(ctx.scenario_debug_log_file)
+        sys.stderr.set_other_stream(ctx.scenario_debug_log_file)
+        logger.init_debug_logger(ctx.scenario_debug_log_file)
+
     # internal cucu config variables
     CONFIG["SCENARIO_RUN_ID"] = uuid.uuid1().hex
 
@@ -96,7 +115,7 @@ def after_scenario(ctx, scenario):
         for browser in ctx.browsers:
             # save the browser logs to the current scenarios results directory
             browser_log_filepath = os.path.join(
-                ctx.scenario_dir, "logs", "browser_console.log"
+                ctx.scenario_logs_dir, "browser_console.log"
             )
 
             os.makedirs(os.path.dirname(browser_log_filepath), exist_ok=True)

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -120,8 +120,9 @@ def after_scenario(ctx, scenario):
 
 
 def before_step(ctx, step):
-    step.stdout = []
-    step.stderr = []
+    sys.stdout.captured()
+    sys.stderr.captured()
+
     ctx.current_step = step
     ctx.start_time = time.monotonic()
 
@@ -131,12 +132,11 @@ def before_step(ctx, step):
 
 
 def after_step(ctx, step):
-    ctx.end_time = time.monotonic()
-    ctx.previous_step_duration = ctx.end_time - ctx.start_time
-
-    # grab the captured output during the step run and reset the wrappers
     step.stdout = sys.stdout.captured()
     step.stderr = sys.stderr.captured()
+
+    ctx.end_time = time.monotonic()
+    ctx.previous_step_duration = ctx.end_time - ctx.start_time
 
     if ctx.browser is not None and not ctx.substep_increment:
         step_name = escape_filename(step.name)

--- a/src/cucu/formatter/junit.py
+++ b/src/cucu/formatter/junit.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+import bs4
+import os
+import traceback
+
+from behave.formatter.base import Formatter
+from behave.model_core import Status
+from bs4.formatter import XMLFormatter
+from cucu.config import CONFIG
+from datetime import datetime
+from xml.sax.saxutils import escape
+
+
+class CucuJUnitFormatter(Formatter):
+    name = "cucu-junit"
+    description = "JUnit Formater"
+
+    def __init__(self, stream_opener, config):
+        super(CucuJUnitFormatter, self).__init__(stream_opener, config)
+        self.xml_root = None
+        self.current_scenario = None
+        self.current_scenario_traceback = None
+        self.current_scenario_duration = 0.0
+        self.current_scenario_results = {}
+        self.feature_timestamp = None
+        self.steps = []
+
+    # -- FORMATTER API:
+    def uri(self, uri):
+        pass
+
+    def feature(self, feature):
+        date_now = datetime.now()
+        self.feature_results = {
+            "name": escape(feature.name),
+            "tests": 0,
+            "errors": 0,
+            "failures": 0,
+            "skipped": 0,
+            "timestamp": date_now.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
+            "scenarios": {},
+        }
+
+    def background(self, background):
+
+        # -- ADD BACKGROUND STEPS: Support *.feature file regeneration.
+        for step_ in background.steps:
+            self.step(step_)
+
+    def update_scenario(self):
+        if self.current_scenario is not None:
+            self.current_scenario_results["time"] = str(
+                round(self.current_scenario_duration, 3)
+            )
+            self.current_scenario_results[
+                "status"
+            ] = self.current_scenario.compute_status().name
+
+            if self.current_scenario_traceback is not None:
+                failure = traceback.format_tb(self.current_scenario_traceback)
+                self.current_scenario_results["failure"] = failure
+
+    def scenario(self, scenario):
+        self.update_scenario()
+
+        self.current_scenario = scenario
+        self.current_scenario_traceback = None
+        self.current_scenario_duration = 0.0
+        self.current_scenario_results = {
+            "status": "pending",
+            "time": "n/a",
+            "failure": None,
+        }
+
+        scenario_name = escape(scenario.name)
+        self.feature_results["scenarios"][
+            scenario_name
+        ] = self.current_scenario_results
+
+        # we write out every new scenario into the JUnit results output which
+        # which allows us to have a valid JUnit XML results file per feature
+        # file currently running even if the process crashes or is killed so we
+        # can still generate valid reports from every run.
+        self.write_results(self.feature_results)
+
+    def match(self, step):
+        pass
+
+    def step(self, step):
+        self.steps.append(step)
+
+    def insert_step(self, step, index=-1):
+        if index == -1:
+            self.steps.append(step)
+        else:
+            self.steps.insert(index, step)
+
+    def result(self, step):
+        if step.status == Status.failed:
+            self.current_scenario_traceback = step.exc_traceback
+
+        self.current_scenario_duration += step.duration
+
+    def eof(self):
+        """
+        end of file for the feature and this is when we write the updated
+        results to the file
+        """
+        self.update_scenario()
+        self.write_results(self.feature_results)
+
+    def close(self):
+        pass
+
+    def write_results(self, results):
+        """
+        given a feature results dictionary that looks like so:
+            {
+                "name": "name of the feature",
+                "tests": 0,
+                "errors": 0,
+                "failures": 0,
+                "skipped": 0,
+                "timestamp": "",
+                "scnearios": {
+                    "scenario name": {
+                        "status": "passed/failed/skipped",
+                        "time": "0.0000":
+                        "stdout": "",
+                        "stderr": "",
+                    },
+                    ...
+                }
+            }
+        """
+
+        # custom attribute ordering so attributes are printed in a consistent
+        # and desired order
+        class SortAttributes(XMLFormatter):
+            def attributes(self, tag):
+                ordered = [
+                    "classname",
+                    "name",
+                    "tests",
+                    "errors",
+                    "failures",
+                    "skipped",
+                    "status",
+                    "timestamp",
+                    "time",
+                ]
+
+                return [
+                    (attr, tag[attr]) for attr in ordered if attr in tag.attrs
+                ]
+
+        soup = bs4.BeautifulSoup()
+        testsuite = bs4.Tag(name="testsuite")
+        testsuite["name"] = results["name"]
+        testsuite["tests"] = results["tests"]
+        testsuite["errors"] = results["errors"]
+        testsuite["failures"] = results["failures"]
+        testsuite["skipped"] = results["skipped"]
+        testsuite["timestamp"] = results["timestamp"]
+        soup.append(testsuite)
+
+        for scenario_name in results["scenarios"]:
+            scenario = results["scenarios"][scenario_name]
+            testcase = bs4.Tag(name="testcase")
+            testcase["classname"] = results["name"]
+            testcase["name"] = scenario_name
+            testcase["status"] = scenario["status"]
+            testcase["time"] = scenario["time"]
+
+            if scenario["failure"] is not None:
+                failure_message = "\n".join(scenario["failure"])
+                failure = bs4.Tag(name="failure")
+                failure.append(bs4.CData(failure_message))
+                testcase.append(failure)
+
+            testsuite.append(testcase)
+
+        junit_dir = CONFIG["CUCU_JUNIT_DIR"]
+
+        if not os.path.exists(junit_dir):
+            os.makedirs(junit_dir)
+
+        feature_name = results["name"].replace(" ", "_")
+        output_filepath = os.path.join(junit_dir, f"TESTS-{feature_name}.xml")
+        with open(output_filepath, "w", encoding="utf-8") as output:
+            output.write(soup.prettify(formatter=SortAttributes()))

--- a/src/cucu/logger.py
+++ b/src/cucu/logger.py
@@ -5,13 +5,41 @@ from functools import wraps
 
 
 def init_logging(logging_level):
-    format = "%(asctime)s %(levelname)s %(message)s"
-    logging.basicConfig(level=logging_level, format=format, stream=sys.stdout)
+    """
+    initialize the cucu logger
+    """
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    handler.setLevel(logging_level)
+
+    logging.getLogger().addHandler(handler)
+    logging.getLogger().setLevel(logging.DEBUG)
+
     logging.debug("logger initialized")
 
     logging.getLogger("parse").setLevel(logging.WARNING)
     logging.getLogger("selenium").setLevel(logging.WARNING)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+
+def init_debug_logger(output_file):
+    """
+    initialize a debug logger handler that runs at debug level and pushes
+    all of the logs to the output file provided without affecting the logging
+    of the main root logger
+    """
+    # assume that there's only 2 loggers the first one is the console one and
+    # the second one if present is a previously set debug logger for the
+    # previously executed scenario
+    if len(logging.getLogger().handlers) != 1:
+        logging.getLogger().removeHandler(logging.getLogger().handlers[1])
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    handler = logging.StreamHandler(output_file)
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG)
+    logging.getLogger().addHandler(handler)
 
 
 @wraps(logging.debug)

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -85,7 +85,9 @@ def generate(results, basepath):
                 log_files = []
 
                 for log_file in glob.iglob(os.path.join(logs_filepath, "*.*")):
-                    log_filepath = log_file.replace(f"{scenario_filepath}/", "")
+                    log_filepath = log_file.removeprefix(
+                        f"{scenario_filepath}/"
+                    )
 
                     if ".console." in log_filepath:
                         log_filepath += ".html"
@@ -96,32 +98,31 @@ def generate(results, basepath):
                             "name": os.path.basename(log_file),
                         }
                     )
-
                 scenario["logs"] = log_files
 
-                for log_file in log_files:
-                    if ".console." in log_file["name"]:
-                        converter = Ansi2HTMLConverter(dark_bg=False)
-                        log_file_filepath = os.path.join(
-                            scenario_filepath, "logs", log_file["name"]
-                        )
+                only_console_logs = lambda log: ".console." in log["name"]
+                for log_file in filter(only_console_logs, log_files):
+                    converter = Ansi2HTMLConverter(dark_bg=False)
+                    log_file_filepath = os.path.join(
+                        scenario_filepath, "logs", log_file["name"]
+                    )
 
-                        input_data = None
-                        with open(
-                            log_file_filepath, "r", encoding="utf8"
-                        ) as log_file_input:
-                            input_data = log_file_input.read()
+                    input_data = None
+                    with open(
+                        log_file_filepath, "r", encoding="utf8"
+                    ) as log_file_input:
+                        input_data = log_file_input.read()
 
-                        html = "\n".join(
-                            [
-                                converter.convert(line)
-                                for line in input_data.split("\n")
-                            ]
-                        )
-                        with open(
-                            log_file_filepath + ".html", "w", encoding="utf8"
-                        ) as log_file_output:
-                            log_file_output.write(html)
+                    html = "\n".join(
+                        [
+                            converter.convert(line)
+                            for line in input_data.split("\n")
+                        ]
+                    )
+                    with open(
+                        log_file_filepath + ".html", "w", encoding="utf8"
+                    ) as log_file_output:
+                        log_file_output.write(html)
 
             scenario["duration"] = scenario_duration
             scenario["total_steps"] = total_steps


### PR DESCRIPTION
* first few steps towards getting a per sceanrio `cucu.debug.log` file
  which would contain all console logs and by default the debug logger
  logs while not cluttering the actual console with logs that one only
  needs once we want to debug a specific test run.

* in order to do this we have to stop relying on the behave junit
  formatter which also allows us to now create junit files for tests
  that have finished and we have a results and not a partial file that
  could then make CI blow up due to parsing issues.