### PR TITLE
move the way we're setting selenium timeouts in a better place

### DIFF
--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -27,9 +27,6 @@ def init():
     """
     initialize any selenium specific needs
     """
-    timeout = float(config.CONFIG["CUCU_SELENIUM_DEFAULT_TIMEOUT_S"])
-    RemoteConnection.set_timeout(timeout)
-
     if config.CONFIG["CUCU_BROWSER"] == "chrome":
         try:
             with DisableLogger():
@@ -54,6 +51,13 @@ class Selenium(Browser):
     def open(
         self, browser, headless=False, selenium_remote_url=None, detach=False
     ):
+        if selenium_remote_url is None:
+            init()
+
+        else:
+            timeout = float(config.CONFIG["CUCU_SELENIUM_DEFAULT_TIMEOUT_S"])
+            RemoteConnection.set_timeout(timeout)
+
         height = config.CONFIG["CUCU_BROWSER_WINDOW_HEIGHT"]
         width = config.CONFIG["CUCU_BROWSER_WINDOW_WIDTH"]
         cucu_downloads_dir = config.CONFIG["CUCU_BROWSER_DOWNLOADS_DIR"]

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -223,9 +223,6 @@ def run(
     # need to set this before initializing any browsers below
     os.environ["CUCU_BROWSER"] = browser.lower()
 
-    if CONFIG["CUCU_SELENIUM_REMOTE_URL"] is None:
-        selenium.init()
-
     if junit is None:
         junit = results
 


### PR DESCRIPTION
* this should fix it so our CI runs do not get stuck due to the timeouts
  not being set closer to when we're actually about to use a remote
  selenium setup.