### PR TITLE
more appropriate use of makedirs

### DIFF
--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -210,8 +210,7 @@ def run(
             if os.path.exists(results):
                 shutil.rmtree(results)
 
-        if not os.path.exists(results):
-            os.makedirs(results)
+        os.makedirs(results, exist_ok=True)
 
     if selenium_remote_url is not None:
         os.environ["CUCU_SELENIUM_REMOTE_URL"] = selenium_remote_url

--- a/src/cucu/formatter/junit.py
+++ b/src/cucu/formatter/junit.py
@@ -181,9 +181,7 @@ class CucuJUnitFormatter(Formatter):
             testsuite.append(testcase)
 
         junit_dir = CONFIG["CUCU_JUNIT_DIR"]
-
-        if not os.path.exists(junit_dir):
-            os.makedirs(junit_dir)
+        os.makedirs(junit_dir, exist_ok=True)
 
         feature_name = results["name"].replace(" ", "_")
         output_filepath = os.path.join(junit_dir, f"TESTS-{feature_name}.xml")

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -163,8 +163,7 @@ def generate(results, basepath):
 
     for feature in features:
         feature_basepath = os.path.join(basepath, feature["name"])
-        if not os.path.exists(feature_basepath):
-            os.makedirs(feature_basepath)
+        os.makedirs(feature_basepath, exist_ok=True)
 
         scenarios = feature["elements"]
         rendered_feature_html = feature_template.render(
@@ -183,9 +182,7 @@ def generate(results, basepath):
         for scenario in scenarios:
             steps = scenario["steps"]
             scenario_basepath = os.path.join(feature_basepath, scenario["name"])
-
-            if not os.path.exists(scenario_basepath):
-                os.makedirs(scenario_basepath)
+            os.makedirs(scenario_basepath, exist_ok=True)
 
             scenario_output_filepath = os.path.join(
                 scenario_basepath, "index.html"


### PR DESCRIPTION
* instead of guarding with an `os.path.exists` we should let the
  underlying function know that `exists_ok=True` as I caught one
  situation with running with `--workers` > 1 where we failed to create
  because the directory existed as you can see there is a small window
  of time between `os.path.exists` and actually creating the directory
  where two concurrent processes could lead to one of them failing to
  create the directory.