### PR TITLE
fix cucu reports for multiline outputs

### DIFF
--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -78,6 +78,9 @@ def generate(results, basepath):
                 if "result" in step:
                     scenario_duration += step["result"]["duration"]
 
+                if "text" in step and not isinstance(step["text"], list):
+                    step["text"] = [step["text"]]
+
                 step_index += 1
             logs_filepath = os.path.join(scenario_filepath, "logs")
 

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -84,7 +84,9 @@
             <tr class="d-flex">
                 <td class="col-11" colspan="2">
                     <pre style="color: black; margin: 0">       """</pre>
-                    <pre style="color: black; margin: 0">       {{ step['text'] }}</pre>
+                    {% for line in step['text'] %}
+                        <pre style="color: black; margin: 0">       {{ line }}</pre>
+                    {% endfor %}
                     <pre style="color: black; margin: 0">       """</pre>
                 </td>
             </tr>


### PR DESCRIPTION
* for whatever reason behave either gives you a single line as a string
  or multiple lines as an array and this was making the output in the
  case of multiple lines appear as a list of those which looked silly