### PR TITLE
cleaning up console logging

### DIFF
--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -158,36 +158,36 @@ Feature: Run outputs
       Feature: Echo
 
         Scenario: Echo an environment variable
+      [\s\S]*
       current shell is '.*'
-
-          Given I echo "current shell is '\{SHELL\}'" .*
+      [\s\S]*
+          Given I echo "current shell is '\{SHELL\}'"       .*
           # SHELL=".*"
       [\s\S]*
       current user is '.*'
 
-            And I echo the following                 .*
+            And I echo the following                        .*
               \"\"\"
               current user is '\{USER\}'
               \"\"\"
             # USER=".*"
-      [\s\S]*
       current working directory is '.*'
-
-            And I echo "current working directory is '\{PWD\}'"  .*
+      [\s\S]*
+            And I echo "current working directory is '\{PWD\}'" .*
             # PWD=".*"
       [\s\S]*
       \{
         "user": ".*"
       \}
-
-            And I echo the following                 .*
+      [\s\S]*
+            And I echo the following                       .*
               \"\"\"
               \\\\{
                 "user": "\{USER\}"
               \\\\}
               \"\"\"
             # USER=".*"
-
+      [\s\S]*
       1 feature passed, 0 failed, 0 skipped
       1 scenario passed, 0 failed, 0 skipped
       4 steps passed, 0 failed, 0 skipped, 0 undefined

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -136,7 +136,7 @@ Feature: Run outputs
       And I should see "{STDERR}" is empty
 
   Scenario: User gets JUnit XML results file as expected
-    Given I run the command "cucu run data/features/echo.feature --results {CUCU_RESULTS_DIR}/validate_junit_xml_results" and save stdout to "STDOUT", exit code to "EXIT_CODE"
+    Given I run the command "cucu run data/features/echo.feature --results {CUCU_RESULTS_DIR}/validate_junit_xml_results" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Echo.xml"
       And I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Echo.xml" matches the following:
       """
@@ -144,4 +144,49 @@ Feature: Run outputs
        <testcase classname="Echo" name="Echo an environment variable" status="passed" time=".*">
        </testcase>
       </testsuite>
+      """
+
+  Scenario: User gets exact expected output from various console outputs
+    Given I run the command "cucu run data/features/echo.feature --results {CUCU_RESULTS_DIR}/validate_junit_xml_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      # {SHELL} and {PWD} contain slashes which we don't have a good way of
+      # escaping in the tests yet so we'll just .* to match them and for the
+      # crazy looking 4 backslashes its because the original test has 2
+      # backslashes and in order to escape each one we need another 2 so we end
+      # up with 4 backlslashes
+      And I should see "{STDOUT}" matches the following
+      """
+      Feature: Echo
+
+        Scenario: Echo an environment variable
+      current shell is '.*'
+
+          Given I echo "current shell is '\{SHELL\}'" .*
+          # SHELL=".*"
+      current user is '.*'
+
+            And I echo the following                 .*
+              \"\"\"
+              current user is '\{USER\}'
+              \"\"\"
+            # USER="{USER}"
+      current working directory is '.*'
+
+            And I echo "current working directory is '\{PWD\}'"  .*
+            # PWD=".*"
+      \{
+        "user": "{USER}"
+      \}
+
+            And I echo the following                 .*
+              \"\"\"
+              \\\\{
+                "user": "\{USER\}"
+              \\\\}
+              \"\"\"
+            # USER="{USER}"
+
+      1 feature passed, 0 failed, 0 skipped
+      1 scenario passed, 0 failed, 0 skipped
+      4 steps passed, 0 failed, 0 skipped, 0 undefined
+      [\s\S]*
       """

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -162,6 +162,7 @@ Feature: Run outputs
 
           Given I echo "current shell is '\{SHELL\}'" .*
           # SHELL=".*"
+      [\s\S]*
       current user is '.*'
 
             And I echo the following                 .*
@@ -169,10 +170,12 @@ Feature: Run outputs
               current user is '\{USER\}'
               \"\"\"
             # USER=".*"
+      [\s\S]*
       current working directory is '.*'
 
             And I echo "current working directory is '\{PWD\}'"  .*
             # PWD=".*"
+      [\s\S]*
       \{
         "user": ".*"
       \}

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -168,13 +168,13 @@ Feature: Run outputs
               \"\"\"
               current user is '\{USER\}'
               \"\"\"
-            # USER="{USER}"
+            # USER=".*"
       current working directory is '.*'
 
             And I echo "current working directory is '\{PWD\}'"  .*
             # PWD=".*"
       \{
-        "user": "{USER}"
+        "user": ".*"
       \}
 
             And I echo the following                 .*
@@ -183,7 +183,7 @@ Feature: Run outputs
                 "user": "\{USER\}"
               \\\\}
               \"\"\"
-            # USER="{USER}"
+            # USER=".*"
 
       1 feature passed, 0 failed, 0 skipped
       1 scenario passed, 0 failed, 0 skipped

--- a/src/cucu/formatter/cucu.py
+++ b/src/cucu/formatter/cucu.py
@@ -45,15 +45,25 @@ class CucuFormatter(Formatter):
 
         return self._multiline_indentation
 
-    def write_tags(self, tags, indent=None):
+    def write_tags(self, tags, indent=None, for_feature=False):
+        """
+        writes the tags for a scenario or feature and takes extra care to be
+        sure to indent corectly for scenarios when `indent` is specified. We
+        also handle putting new lines in the right locations if its a scenario
+        or feature based on `for_feature` boolean flag.
+        """
         indent = indent or ""
         if tags:
             text = " @".join(tags)
-            self.stream.write(self.colorize(f"{indent}@{text}\n", "cyan"))
+            line = self.colorize(f"{indent}@{text}", "cyan")
+            if for_feature:
+                self.stream.write(f"{line}\n")
+            else:
+                self.stream.write(f"\n{line}")
 
     # -- IMPLEMENT-INTERFACE FOR: Formatter
     def feature(self, feature):
-        self.write_tags(feature.tags)
+        self.write_tags(feature.tags, for_feature=True)
         text = f'{self.colorize(feature.keyword, "magenta")}: {feature.name}\n'
         self.stream.write(text)
 

--- a/src/cucu/formatter/json.py
+++ b/src/cucu/formatter/json.py
@@ -108,12 +108,13 @@ class CucuJSONFormatter(Formatter):
         return table_data
 
     def insert_step(self, step, index=-1):
+        is_substep = getattr(step, "is_substep", False)
         s = {
             "keyword": step.keyword,
             "step_type": step.step_type,
             "name": step.name,
             "location": six.text_type(step.location),
-            "substep": "substep" in step.__dict__,
+            "substep": is_substep,
         }
 
         if step.text:

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -41,7 +41,7 @@ def run_steps(context, steps_text):
             for step in steps:
                 for formatter in context._runner.formatters:
                     step_index = formatter.steps.index(current_step)
-                    step.substep = True
+                    step.is_substep = True
                     formatter.insert_step(step, index=step_index + index)
                 index += 1
 


### PR DESCRIPTION
Caught some situations where the last line of some console output or even sub step printing was getting blown away when writing the next step to the console, see before:

```
╰─ cucu run data/features/echo.feature
Feature: Echo

  Scenario: Echo an environment variable
    Given I echo "current shell is '{SHELL}'"
current shell is '/bin/zsh'
    Given I echo "current shell is '{SHELL}'"               #  in 0.001s
    # SHELL="/bin/zsh"
      And I echo the following
current user is 'rodney.gomes'
      And I echo the following                              #  in 0.000s
        """
        current user is '{USER}'
        """
      And I echo "current working directory is '{PWD}'"
current working directory is '/Users/rodney.gomes/work/cucu'
      And I echo "current working directory is '{PWD}'"     #  in 0.000s
      # PWD="/Users/rodney.gomes/work/cucu"
      And I echo the following
{
  "user": "rodney.gomes"
}
      And I echo the following                              #  in 0.000s
        """
        \{
          "user": "{USER}"
        \}
        """

1 feature passed, 0 failed, 0 skipped
1 scenario passed, 0 failed, 0 skipped
4 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m0.001s
```

And after:

```
╰─ ./bin/cucu run data/features/echo.feature
Feature: Echo

  Scenario: Echo an environment variable
    Given I echo "current shell is '{SHELL}'"
current shell is '/bin/zsh'
    Given I echo "current shell is '{SHELL}'"               #  in 0.000s
    # SHELL="/bin/zsh"
      And I echo the following
current user is 'rodney.gomes'
      And I echo the following                              #  in 0.000s
        """
        current user is '{USER}'
        """
      # USER="rodney.gomes"
      And I echo "current working directory is '{PWD}'"
current working directory is '/Users/rodney.gomes/work/cucu'
      And I echo "current working directory is '{PWD}'"     #  in 0.000s
      # PWD="/Users/rodney.gomes/work/cucu"
      And I echo the following
{
  "user": "rodney.gomes"
}
      And I echo the following                              #  in 0.000s
        """
        \{
          "user": "{USER}"
        \}
        """
      # USER="rodney.gomes"

1 feature passed, 0 failed, 0 skipped
1 scenario passed, 0 failed, 0 skipped
4 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m0.001s
```

If you look closely the the value of {USER} isn’t printed in two places as a comment as it gets obliterated by the next step logging.