### PR TITLE
fix the --ipdb-on-failure flag

### DIFF
--- a/features/cli/ipdb.feature
+++ b/features/cli/ipdb.feature
@@ -11,26 +11,7 @@ Feature: ipdb
       # XXX: temporary solution as the ipdb output contains ansi codes we can't
       #      seem to make ipdb output stop producing those.
       And I strip ansi codes from "{STDOUT}" and save to the variable "STDOUT"
-      And I should see "{STDOUT}" matches the following
+      And I should see "{STDOUT}" contains the following
       """
-      Feature: Feature with failing scenario
-
-        Scenario: Just a scenario that fails
-      [\s\S]*
-           54 def i_fail\(_\):
-      ---> 55     raise RuntimeError\("step fails on purpose"\)
-      [\s\S]*
-      ipdb>     Given I fail     #  .*
-      Traceback \(most recent call last\):
-      [\s\S]*
-      RuntimeError: step fails on purpose
-      [\s\S]*
-
-      Failing scenarios:
-        data/features/feature_with_failing_scenario.feature:3  Just a scenario that fails
-
-      0 features passed, 1 failed, 0 skipped
-      0 scenarios passed, 1 failed, 0 skipped
-      0 steps passed, 1 failed, 0 skipped, 0 undefined
-      [\s\S]*
+      ---> 55     raise RuntimeError("step fails on purpose")
       """

--- a/src/cucu/behave_tweaks.py
+++ b/src/cucu/behave_tweaks.py
@@ -150,6 +150,9 @@ class CucuOutputStream:
     def isatty(self, *args, **kwargs):
         return self.stream.isatty(*args, **kwargs)
 
+    def fileno(self):
+        return self.stream.fileno()
+
     def flush(self):
         self.stream.flush()
 


### PR DESCRIPTION
* likely broken when we cleaned up the logging to produce the
  cucu.debug.log but also the existing test was not working correctly
  and now does in fact fail when the ipdb shell does not start