### PR TITLE
cucu steps should not fail when there are undefined steps

### DIFF
--- a/features/cli/lint.feature
+++ b/features/cli/lint.feature
@@ -23,9 +23,13 @@ Feature: Lint
       """
       You can implement step definitions for undefined steps with these snippets
       """
+      And I should see "{STDOUT}" contains the following:
+      """
+      failure loading some steps, see above for details
+      """
       And I should see "{STDERR}" contains the following:
       """
-      failed to load steps, see above for details
+      Error: linting errors found, but not fixed, see above for details
       """
 
   Scenario: User can find and fix indentation violations
@@ -174,7 +178,11 @@ Feature: Lint
       """
       RuntimeError: boom
       """
+      And I should see "{STDOUT}" contains the following:
+      """
+      failure loading some steps, see above for details
+      """
       And I should see "{STDERR}" contains the following:
       """
-      failed to load steps, see above for details
+      Error: linting errors found, but not fixed, see above for details
       """

--- a/features/cli/steps.feature
+++ b/features/cli/steps.feature
@@ -45,5 +45,5 @@ Feature: Steps
       """
       And I should see "{STDERR}" contains the following:
       """
-      failed to load steps, see above for details
+      Failure loading some steps, see above for details
       """

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -386,8 +386,17 @@ def lint(filepath, fix):
             if violations:
                 for violation in violations:
                     violations_found += 1
+
+                    if violation["type"] == "steps_error":
+                        print(violation["message"])
+                        print(
+                            "failure loading some steps, see above for details"
+                        )
+                        print("")
+                        continue
+
                     location = violation["location"]
-                    type = violation["type"][0].upper()
+                    _type = violation["type"][0].upper()
                     message = violation["message"]
                     suffix = ""
 
@@ -400,7 +409,9 @@ def lint(filepath, fix):
 
                     filepath = location["filepath"]
                     line_number = location["line"] + 1
-                    print(f"{filepath}:{line_number}: {type} {message}{suffix}")
+                    print(
+                        f"{filepath}:{line_number}: {_type} {message}{suffix}"
+                    )
 
     if violations_found != 0:
         if violations_found == violations_fixed:

--- a/src/cucu/cli/steps.py
+++ b/src/cucu/cli/steps.py
@@ -34,10 +34,6 @@ def load_cucu_steps(filepath=None):
 
     process = subprocess.run(args, capture_output=True)
 
-    if process.returncode != 0:
-        print(process.stderr.decode("utf8"))
-        raise RuntimeError("failed to load steps, see above for details")
-
     steps_doc_output = process.stdout.decode("utf8")
     for cucu_step in steps_doc_output.split("@step"):
         # Each line of a step definition looks like so:
@@ -53,6 +49,16 @@ def load_cucu_steps(filepath=None):
         #     Location: src/cucu/behave_tweaks.py:64
         #
         if cucu_step.strip() == "":
+            continue
+
+        if not cucu_step.startswith("("):
+            #
+            # any block of lines between the `@step` that doesn't start with the
+            # character ( is an error being reported behave when loading steps
+            # and we'll ignore it when processing the step definitions and then
+            # report the actual underlying trace reported in STDERR below
+            #
+            print("unable to parse some step lines")
             continue
 
         lines = cucu_step.split("\n")
@@ -84,20 +90,29 @@ def load_cucu_steps(filepath=None):
             step_name = match.group(1)
             steps_cache[step_name] = None
 
-    return steps_cache
+    error = None
+
+    if process.returncode != 0:
+        error = process.stderr.decode("utf8")
+
+    return (steps_cache, error)
 
 
 def print_json_steps(filepath=None):
     """
     pretty print the steps in a JSON fart
     """
-    steps = load_cucu_steps(filepath=filepath)
+    steps, steps_error = load_cucu_steps(filepath=filepath)
     print(json.dumps(steps, indent=2, sort_keys=True))
 
 
 def print_human_readable_steps(filepath=None):
-    steps = load_cucu_steps(filepath=filepath)
+    steps, steps_error = load_cucu_steps(filepath=filepath)
 
     for step_name in steps:
         if steps[step_name] is not None:
             print(f"{step_name}")
+
+    if steps_error is not None:
+        print(steps_error)
+        raise RuntimeError("Failure loading some steps, see above for details")

--- a/src/cucu/language_server/core.py
+++ b/src/cucu/language_server/core.py
@@ -27,8 +27,9 @@ def find_completions(step_fragment, steps_cache=None):
         an Array tuples of step name and locations.
     """
     items = []
+
     if steps_cache is None:
-        steps_cache = load_cucu_steps()
+        steps_cache, _ = load_cucu_steps()
 
     # first pass try to find steps that start with fragment provided
     for step in steps_cache.keys():
@@ -59,7 +60,7 @@ def find_completions(step_fragment, steps_cache=None):
 
 def start(port=None):
     server = LanguageServer()
-    steps_cache = load_cucu_steps()
+    steps_cache, _ = load_cucu_steps()
     logging.basicConfig(filename="pygls.log", filemode="w", level=logging.DEBUG)
 
     @server.feature(COMPLETION, CompletionOptions(trigger_characters=[","]))

--- a/src/cucu/lint/linter.py
+++ b/src/cucu/lint/linter.py
@@ -201,7 +201,15 @@ def lint(filepath):
     """
     # load the base lint rules
     rules = load_builtin_lint_rules()
-    steps = load_cucu_steps(filepath=filepath)
+    steps, steps_error = load_cucu_steps(filepath=filepath)
+
+    if steps_error:
+        yield [
+            {
+                "type": "steps_error",
+                "message": steps_error,
+            }
+        ]
 
     filepath = os.path.abspath(filepath)
 

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -21,7 +21,7 @@ def test_find_completions_returns_something_when_prefix_does_not_match():
 
 
 def test_load_cucu_steps_returns_valid_list_of_existing_steps():
-    steps = load_cucu_steps()
+    steps, _ = load_cucu_steps()
 
     for step_name in steps.keys():
         step_details = steps[step_name]


### PR DESCRIPTION
allow `cucu steps` to produce the step listing and only then report on the undefined steps.