### PR TITLE
fixes issue with hiding secrets in bytes output

### DIFF
--- a/src/cucu/behave_tweaks.py
+++ b/src/cucu/behave_tweaks.py
@@ -124,8 +124,13 @@ def hide_secrets(line):
         if secret is not None:
             value = CONFIG[secret]
             if value is not None:
-                line = line.replace(value, "*" * len(value))
+                replacement = "*" * len(value)
 
+                if isinstance(line, bytes):
+                    value = bytes(value, "utf8")
+                    replacement = bytes(replacement, "utf8")
+
+                line = line.replace(value, replacement)
     return line
 
 
@@ -133,6 +138,11 @@ class CucuOutputStream:
     """
     encapsulates a lot of the logic to handle capturing step by step console
     logging but also redirecting logging at runtime to another stream
+
+
+    FYI: in order to print to the screen you must use directly the sys.stdout object
+         and write to it here as doing something like `print(...)` will result
+         in an infinite recursive loop and break
     """
 
     def __init__(self, stream, other_stream=None):


### PR DESCRIPTION
* the bytes output really only happening when one jumps into the ipdb
  session and this basically impedes folks from using --ipdb-on-failure
  at the moment. To allow them to debug runs and then come back to this
  for hiding secrets in binary content (although this path does not
  trigger at all for console output or log file outputs).