### PR TITLE
handle errors when running external features

### DIFF
--- a/features/flow_control/run_other_features.feature
+++ b/features/flow_control/run_other_features.feature
@@ -4,3 +4,9 @@ Feature: Run other features
 
   Scenario: User can run a specific feature file
     Given I run the feature at "data/features/echo.feature" with results at "{CUCU_RESULTS_DIR}/run_feature_echo_results"
+
+  Scenario: User gets an error when running a failing feature file
+    Given I expect the following step to fail with ""cucu run data/features/feature_with_failing_scenario.feature --results {CUCU_RESULTS_DIR}/run_failing_feature_from_scenario_results" exited with 1, see above for details"
+      """
+      Then I run the feature at "data/features/feature_with_failing_scenario.feature" with results at "{CUCU_RESULTS_DIR}/run_failing_feature_from_scenario_results"
+      """

--- a/src/cucu/steps/flow_control_steps.py
+++ b/src/cucu/steps/flow_control_steps.py
@@ -1,4 +1,6 @@
 import os
+import shlex
+import subprocess
 import time
 
 from cucu import logger, retry, run_steps, step
@@ -134,7 +136,14 @@ def stop_the_timer(ctx, name):
 
 
 def run_feature(ctx, filepath, results):
-    os.system(f"cucu run {filepath} --results {results}")
+    command = f"cucu run {filepath} --results {results}"
+    process = subprocess.run(shlex.split(command))
+
+    return_code = process.returncode
+    if return_code != 0:
+        raise RuntimeError(
+            f'"{command}" exited with {return_code}, see above for details'
+        )
 
 
 @step(


### PR DESCRIPTION
* we missed a test for this and that of course meant the whole code path
  was bugy