### PR TITLE
quick fix to run the external command in a shell

### DIFF
--- a/src/cucu/steps/flow_control_steps.py
+++ b/src/cucu/steps/flow_control_steps.py
@@ -1,5 +1,4 @@
 import os
-import shlex
 import subprocess
 import time
 
@@ -137,7 +136,7 @@ def stop_the_timer(ctx, name):
 
 def run_feature(ctx, filepath, results):
     command = f"cucu run {filepath} --results {results}"
-    process = subprocess.run(shlex.split(command))
+    process = subprocess.run(command, shell=True)
 
     return_code = process.returncode
     if return_code != 0:


### PR DESCRIPTION
* this resolves the issue of when running cucu as an installed package
  and not through poetry or the ./bin/cucu binary provided. Without this
  change the step would fail to execute since the underlying call to
  exec wouldn't find the `cucu` binary anywhere.