### PR TITLE
rework clipboard step

### DIFF
--- a/src/cucu/steps/browser_steps.py
+++ b/src/cucu/steps/browser_steps.py
@@ -87,7 +87,7 @@ def go_back_on_browser(ctx):
 def save_clipboard_value_to_variable(ctx, variable):
     ctx.check_browser_initialized()
     # create the hidden textarea so we can paste clipboard contents in
-    ctx.browser.execute(
+    textarea = ctx.browser.execute(
         """
     var textarea = document.getElementById('cucu-copy-n-paste')
     if (!textarea) {
@@ -96,13 +96,13 @@ def save_clipboard_value_to_variable(ctx, variable):
         textarea.style.display = 'hidden';
         textarea.style.height = '0px';
         textarea.style.width = '0px';
-        document.body.appendChild(textarea);
+        document.body.insertBefore(textarea, document.body.firstChild);
     }
+    return textarea;
     """
     )
-    # send ctrl+v or cmd+v to that element
-    textarea = ctx.browser.css_find_elements("#cucu-copy-n-paste")[0]
 
+    # send ctrl+v or cmd+v to that element
     if "mac" in ctx.browser.execute("return navigator.platform").lower():
         textarea.send_keys(Keys.COMMAND, "v")
     else:


### PR DESCRIPTION
* we ran into an issue with this on a specific app page where it seemed
  like dangling nodes at the end of the page resulted in them not being
  "interactable" and by trial and error I've found that just appending
  this harmless and temporary element to the DOM before the very first
  element seems to work so for now lets just do that.