### PR TITLE
quick fix for cucu linting completely un-indented files

### DIFF
--- a/features/cli/lint.feature
+++ b/features/cli/lint.feature
@@ -270,3 +270,37 @@ Feature: Lint
       Error: linting errors found, but not fixed, see above for details
 
       """
+
+
+  @regression
+  Scenario: User can lint and fix a file with no indentation
+    Given I create a file at "{CUCU_RESULTS_DIR}/no_indent/environment.py" with the following:
+      """
+      from cucu.environment import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/no_indent/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/no_indent/bad_feature_indentation.feature" with the following:
+      """
+      Feature: Badly indented feature
+
+      Scenario: This is a scenario in a badly indented feature name line
+      Given I echo "foo"
+      When I echo "bar"
+      And I echo "fizz"
+      Then I echo "buzz"
+      """
+     Then I run the command "cucu lint --fix {CUCU_RESULTS_DIR}/no_indent/bad_feature_indentation.feature" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      And I should see the file at "{CUCU_RESULTS_DIR}/no_indent/bad_feature_indentation.feature" has the following:
+      """
+      Feature: Badly indented feature
+
+        Scenario: This is a scenario in a badly indented feature name line
+          Given I echo "foo"
+           When I echo "bar"
+            And I echo "fizz"
+           Then I echo "buzz"
+      """
+

--- a/src/cucu/lint/rules/format.yaml
+++ b/src/cucu/lint/rules/format.yaml
@@ -21,7 +21,7 @@ feature_name_on_first_line:
   current_line:
     match: '^\s+Feature: .*'
   fix:
-    match: '^\s+'
+    match: '^\s*'
     replace: ''
 
 scenario_name_with_appropriate_indentation:
@@ -31,7 +31,7 @@ scenario_name_with_appropriate_indentation:
   current_line:
     match: '^(\s{0,1}|\s{3,})Scenario: .*'
   fix:
-    match: '^\s+'
+    match: '^\s*'
     replace: '  '
 
 given_keyword_indented_correctly:
@@ -40,7 +40,7 @@ given_keyword_indented_correctly:
   current_line:
     match: '^(\s{0,3}|\s{5,})Given .*'
   fix:
-    match: '^\s+'
+    match: '^\s*'
     replace: '    '
 
 when_keyword_indented_correctly:
@@ -49,7 +49,7 @@ when_keyword_indented_correctly:
   current_line:
     match: '^(\s{0,4}|\s{6,})When .*'
   fix:
-    match: '^\s+'
+    match: '^\s*'
     replace: '     '
 
 then_keyword_indented_correctly:
@@ -58,7 +58,7 @@ then_keyword_indented_correctly:
   current_line:
     match: '^(\s{0,4}|\s{6,})Then .*'
   fix:
-    match: '^\s+'
+    match: '^\s*'
     replace: '     '
 
 and_keyword_indented_correctly:
@@ -67,7 +67,7 @@ and_keyword_indented_correctly:
   current_line:
     match: '^(\s{0,5}|\s{7,})And .*'
   fix:
-    match: '^\s+'
+    match: '^\s*'
     replace: '      '
 
 line_with_extraneous_whitespace:


### PR DESCRIPTION
* bug was found where if a file had no indentation the linter would
  just pass without fixing anything and it was simply due to the fact
  that the regex to match on the starting whitespace didn't account for
  "no whitespace".