### PR TITLE
fix bug in write to input when @value is used

### DIFF
--- a/data/www/inputs.html
+++ b/data/www/inputs.html
@@ -28,6 +28,8 @@
     <label>textarea with label</label>          <textarea onkeypress="update('textarea with label');"></textarea><br/>
     <p for="following-input">following input to a textarea</p><input onkeypress="update('following input to a textarea');" id="following-input" type="text"></input><br/>
 
+    <label>input with @value set</label>        <input onkeypress="update('input with @value set');" value="foo"></input><br/>
+
     <!-- load the utility library that can be used to delay the page loading -->
     <script src="js/util.js"></script>
   </body>

--- a/features/browser/inputs.feature
+++ b/features/browser/inputs.feature
@@ -162,3 +162,9 @@ Feature: Inputs
      When I wait up to "10" seconds to write "8675309" into the input "input type=tel"
      Then I should see the previous step took more than "9" seconds
       And I should see "8675309" in the input "input type=tel"
+
+  @wip
+  Scenario: User can write into an input with an @value set and the input is cleared correctly
+    Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
+     Then I write "bar" into the input "input with @value set"
+      And I should see "bar" in the input "input with @value set"

--- a/src/cucu/steps/input_steps.py
+++ b/src/cucu/steps/input_steps.py
@@ -60,6 +60,7 @@ def find_n_write(ctx, name, value, index=0):
     ctx.check_browser_initialized()
 
     input_ = find_input(ctx, name, index=index)
+    input_.clear()
     input_.send_keys(value)
 
 


### PR DESCRIPTION
* found this bug while debugging something else and just decided that
  the `write ... into the input ...` step should clear the input when
  writing into it. The basic issue is that when @value is set then using
  selenium's `send_keys` simply results in appending to the input field.