### PR TITLE
custom failure handlers

### DIFF
--- a/features/cli/report_with_custom_failure_handler.feature
+++ b/features/cli/report_with_custom_failure_handler.feature
@@ -1,0 +1,33 @@
+@report
+Feature: Report with custom failure handler
+  As a developer I want the user to be able to generate reports that contain
+  failures with some custom handling of the failure output
+
+  Scenario: User can register a custom failure handler for reporting
+    Given I create a file at "{CUCU_RESULTS_DIR}/report_with_custom_failure_handling/environment.py" with the following:
+      """
+      from cucu.environment import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/report_with_custom_failure_handling/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      from cucu import register_custom_failure_handler
+
+      def my_failure_handler(feature, scenario):
+        return f"look ma: \{feature.name\}\n"
+
+      register_custom_failure_handler(my_failure_handler)
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/report_with_custom_failure_handling/feature_with_custom_tag_handling.feature" with the following:
+      """
+      Feature: Feature with a failure
+
+        Scenario: Scenario that definitely fails
+          Given I click the button "not there"
+      """
+     Then I run the command "cucu run {CUCU_RESULTS_DIR}/report_with_custom_failure_handling --results {CUCU_RESULTS_DIR}/custom_failure_handler_results --generate-report --report {CUCU_RESULTS_DIR}/custom_failure_handler_report" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+     When I start a webserver at directory "{CUCU_RESULTS_DIR}/custom_failure_handler_report" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
+      And I wait to click the link "Feature with a failure"
+      And I click the link "Scenario that definitely fails"
+     Then I wait to see the text "look ma: Feature with a failure"

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,2 +1,25 @@
 # nopycln: file
+import urllib
+
+from cucu import register_custom_failure_handler
+from cucu.config import CONFIG
 from cucu.environment import *
+
+
+def circle_ci_direct_links_to_reports(feature, scenario):
+    """
+    custom failure handler that will add links from the tests Tab in CircleCI to
+    link directly to our HTML Test Report
+    """
+    build_url = CONFIG["CIRCLE_BUILD_URL"]
+    feature_name = urllib.parse.quote(feature.name)
+    scenario_name = urllib.parse.quote(scenario.name)
+    if build_url is not None:
+        job_id = CONFIG["CIRCLE_WORKFLOW_JOB_ID"]
+        return f"""
+See the HTML Test Report for more details(triple click the link, then copy and paste into your browser):
+https://output.circle-artifacts.com/output/job/{job_id}/artifacts/0/report/{feature_name}/{scenario_name}/index.html
+        """
+
+
+register_custom_failure_handler(circle_ci_direct_links_to_reports)

--- a/src/cucu/__init__.py
+++ b/src/cucu/__init__.py
@@ -18,6 +18,7 @@ from cucu.hooks import (
     register_page_check_hook,
     register_custom_variable_handling,
     register_custom_tags_in_report_handling,
+    register_custom_failure_handler,
 )
 
 from cucu.utils import (

--- a/src/cucu/config.py
+++ b/src/cucu/config.py
@@ -310,3 +310,4 @@ CONFIG.define(
 # cucu internals - we do not expose these as defined variables in `cucu vars`
 CONFIG["__CUCU_AFTER_SCENARIO_HOOKS"] = []
 CONFIG["__CUCU_HTML_REPORT_TAG_HANDLERS"] = {}
+CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"] = []

--- a/src/cucu/hooks.py
+++ b/src/cucu/hooks.py
@@ -126,3 +126,23 @@ def register_custom_tags_in_report_handling(regex, handler):
                         return "<a href="...">{tag}</a>"
     """
     CONFIG["__CUCU_HTML_REPORT_TAG_HANDLERS"][re.compile(regex)] = handler
+
+
+def register_custom_failure_handler(handler):
+    """
+    register a callback function to call when there is a test failure and
+    we want to augment the failure output message in the junit and json results
+    files.
+
+    parameters:
+        handler(feature, scenario):
+          where feature and scenario are the following behave model
+          objects:
+
+            * https://behave.readthedocs.io/en/stable/api.html#behave.model.Feature
+            * https://behave.readthedocs.io/en/stable/api.html#behave.model.Scenario
+
+          You must return a string that will be appended to the top of the
+          failure message in the JSON and JUnit XML results files.
+    """
+    CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"].append(handler)

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -67,7 +67,9 @@
                 {% set step_prefix = "" %}
             {% endif %}
             {% if step['result'] is defined %}
-                {% set step_timing = "# started at {} took {:.3f}s".format(step["result"]["timestamp"], step["result"]["duration"]) %}
+                {% if step['result']['status'] == 'failed' or step['result']['status'] == 'passed' %}
+                    {% set step_timing = "# started at {} took {:.3f}s".format(step["result"]["timestamp"], step["result"]["duration"]) %}
+                {% endif %}
             {% else %}
                 {% set step_timing = "" %}
             {% endif %}


### PR DESCRIPTION
* the idea is to be able to add custom output to our JUnit XML and JSON results files so that we can link to reports when tests fail and being able to make debugging easier for the report reader.