### PR TITLE
fix step handlers

### DIFF
--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -10,7 +10,13 @@ import time
 import os
 
 from click import ClickException
-from cucu import fuzzy, reporter, language_server, logger
+from cucu import (
+    fuzzy,
+    init_global_hook_variables,
+    reporter,
+    language_server,
+    logger,
+)
 from cucu.browser import selenium
 from cucu.config import CONFIG
 from cucu.cli import thread_dumper
@@ -323,6 +329,7 @@ def _generate_report(filepath, output):
 
     os.makedirs(output)
 
+    init_global_hook_variables()
     report_location = reporter.generate(filepath, output)
     print(f"HTML test report at {report_location}")
 

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 from cucu import behave_tweaks
+from cucu import init_global_hook_variables
 from behave.__main__ import main as behave_main
 from datetime import datetime
 
@@ -36,6 +37,7 @@ def behave(
     log_start_n_stop=False,
     redirect_output=False,
 ):
+    init_global_hook_variables()
 
     if not dry_run:
         write_run_details(results, filepath)

--- a/src/cucu/config.py
+++ b/src/cucu/config.py
@@ -305,9 +305,3 @@ CONFIG.define(
     "comma separated list of paths to load cucu lint rules from .yaml files",
     default="",
 )
-
-
-# cucu internals - we do not expose these as defined variables in `cucu vars`
-CONFIG["__CUCU_AFTER_SCENARIO_HOOKS"] = []
-CONFIG["__CUCU_HTML_REPORT_TAG_HANDLERS"] = {}
-CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"] = []

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -13,8 +13,6 @@ from cucu.page_checks import init_page_checks
 from functools import partial
 
 
-init_global_hook_variables()
-
 CONFIG.define(
     "FEATURE_RESULTS_DIR",
     "the results directory for the currently executing feature",
@@ -30,6 +28,8 @@ CONFIG.define(
     "the browser downloads directory for the currently " "executing scenario",
     default=None,
 )
+
+init_global_hook_variables()
 
 
 def escape_filename(string):

--- a/src/cucu/hooks.py
+++ b/src/cucu/hooks.py
@@ -22,8 +22,9 @@ def init_global_hook_variables():
     CONFIG["__CUCU_AFTER_STEP_HOOKS"] = []
 
     CONFIG["__CUCU_PAGE_CHECK_HOOKS"] = {}
-
     CONFIG["__CUCU_HTML_REPORT_TAG_HANDLERS"] = {}
+
+    CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"] = []
 
 
 def init_scenario_hook_variables():


### PR DESCRIPTION
* there's a bug where the same step handlers will get registered again and again when running with `--workers` options which led me to figure out that various hooks are simply not being reset at the right point for our `--workers` to not end up doing a similar thing for other hooks registered at runtime.