### PR TITLE
handle disabled elements correctly

### DIFF
--- a/data/www/buttons.html
+++ b/data/www/buttons.html
@@ -23,6 +23,8 @@
     <label for="button-for">button with label for</label><button id="button-for" onclick="update('button with label for');"></button>
 
     <button onclick="update('disabled button');" disabled>disabled button</button>
+    <button onclick="update('aria-disabled button');" aria-disabled="true">aria-disabled button</button>
+  </body>
   </body>
 
   <!-- load the utility library that can be used to delay the page loading -->

--- a/data/www/checkboxes.html
+++ b/data/www/checkboxes.html
@@ -92,6 +92,8 @@
     <br/>
     <label><input onclick="update('checkbox wrapped with label')" type="checkbox"></input>checkbox wrapped with label</label>
     <br/>
+    <input onclick="update('disabled checkbox')" disabled type="checkbox"><label>disabled checkbox</label></input>
+    <br/>
 
     <label class="container">
         <input type="checkbox" style="display: none">

--- a/data/www/dropdowns.html
+++ b/data/www/dropdowns.html
@@ -9,5 +9,12 @@
           <option value="Green">green</option>
           <option value="Red" selected>red</option>
       </select>
+
+      <label for="pet-names">Pick a pet:</label>
+      <select disabled name="pet-names" id="pet-names">
+          <option value="CheeseBall">CheeseBall</option>
+          <option value="Nugget">Nugget</option>
+          <option value="Tater" selected>Tater</option>
+      </select>
   </body>
 </html>

--- a/data/www/inputs.html
+++ b/data/www/inputs.html
@@ -30,6 +30,8 @@
 
     <label>input with @value set</label>        <input onkeypress="update('input with @value set');" value="foo"></input><br/>
 
+    <label>disabled input</label>               <input onkeypress="update('disabled input');" disabled></input><br/>
+
     <!-- load the utility library that can be used to delay the page loading -->
     <script src="js/util.js"></script>
   </body>

--- a/data/www/links.html
+++ b/data/www/links.html
@@ -22,6 +22,9 @@
     <a href="frames.html">duplicate link!</a>
     </br>
 
+    <a href="frames.html" disabled>disabled link!</a>
+    </br>
+
     <a href="#" onclick="setTimeout(function() {window.open('buttons.html', '_blank');}, 3800);">buttons! in a new tab with a delay</a>
   </body>
 </html>

--- a/data/www/radio_buttons.html
+++ b/data/www/radio_buttons.html
@@ -41,4 +41,8 @@
   <input type="radio" id="blue" name="color" value="blue"><label>blue</label>
   <input type="radio" id="blue" name="color" value="blue"><label>blue</label>
 
+  <label>pick an color</label>
+  <input disabled type="radio" id="red" name="favorite_color" value="red"><label>red</label>
+  <input disabled type="radio" id="green" name="favorite_color" value="green"><label>green</label>
+  <input disabled type="radio" id="blue" name="favorite_color" value="blue"><label>blue</label>
 </html>

--- a/features/browser/buttons.feature
+++ b/features/browser/buttons.feature
@@ -56,7 +56,7 @@ Feature: Buttons
 
   Scenario: User can wait the CUCU_STEP_WAIT_TIMEOUT_S to click a button
     Given I set the variable "CUCU_STEP_WAIT_TIMEOUT_S" to "5"
-    Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/buttons.html?delay_page_load_ms=5000"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/buttons.html?delay_page_load_ms=5000"
      When I wait to click the button "button"
      Then I should see the previous step took more than "4" seconds
 
@@ -101,4 +101,20 @@ Feature: Buttons
       And I expect the following step to fail with "button "disabled button" is not not disabled"
       """
       Then I should see the button "disabled button" is not disabled
+      """
+
+  Scenario: User can not click a disabled button
+    Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/buttons.html"
+      And I should see the button "disabled button" is disabled
+      And I expect the following step to fail with "unable to click the button, as it is disabled"
+      """
+      Then I click the button "disabled button"
+      """
+
+  Scenario: User can not click a aria-disabled button
+    Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/buttons.html"
+      And I should see the button "aria-disabled button" is disabled
+      And I expect the following step to fail with "unable to click the button, as it is disabled"
+      """
+      Then I click the button "aria-disabled button"
       """

--- a/features/browser/checkboxes.feature
+++ b/features/browser/checkboxes.feature
@@ -29,3 +29,10 @@ Feature: Checkboxes
      When I check the checkbox "checkbox wrapped with label"
      Then I should see the checkbox "checkbox wrapped with label" is checked
       And I should see "checkbox wrapped with label" in the input "last touched checkbox:"
+
+  Scenario: User can not check a disabled checkbox
+    Given I should see the checkbox "disabled checkbox" is disabled
+      And I expect the following step to fail with "unable to check the checkbox, as it is disabled"
+      """
+      Then I check the checkbox "disabled checkbox"
+      """

--- a/features/browser/dropdowns.feature
+++ b/features/browser/dropdowns.feature
@@ -18,3 +18,10 @@ Feature: Dropdowns
      Then I should see the option "blue" is not selected on the dropdown "Pick a color"
       And I should see the option "green" is selected on the dropdown "Pick a color"
       And I should see the option "red" is not selected on the dropdown "Pick a color"
+
+  Scenario: User can not select from a disabled dropdown
+    Given I should see the dropdown "Pick a pet"
+      And I expect the following step to fail with "unable to select from the dropdown, as it is disabled"
+      """
+      Then I select the option "CheeseBall" from the dropdown "Pick a pet"
+      """

--- a/features/browser/inputs.feature
+++ b/features/browser/inputs.feature
@@ -163,8 +163,23 @@ Feature: Inputs
      Then I should see the previous step took more than "9" seconds
       And I should see "8675309" in the input "input type=tel"
 
-  @wip
   Scenario: User can write into an input with an @value set and the input is cleared correctly
     Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
      Then I write "bar" into the input "input with @value set"
       And I should see "bar" in the input "input with @value set"
+
+  Scenario: User can write into a disabled input field
+    Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
+     Then I should see the input "disabled input" is disabled
+      And I expect the following step to fail with "unable to write into the input, as it is disabled"
+      """
+      Then I write "foo" into the input "disabled input"
+      """
+
+  Scenario: User can not clear a disabled input field
+    Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
+     Then I should see the input "disabled input" is disabled
+      And I expect the following step to fail with "unable to clear the input, as it is disabled"
+      """
+      Then I clear the input "disabled input"
+      """

--- a/features/browser/links.feature
+++ b/features/browser/links.feature
@@ -20,3 +20,10 @@ Feature: Links
      When I go back on the browser
       And I click the "2nd" link "duplicate link!"
      Then I should see the browser title is "Iframes!"
+
+  Scenario: User can not click a disabled link
+    Given I should see the link "disabled link" is disabled
+      And I expect the following step to fail with "unable to click the link, as it is disabled"
+      """
+      Then I click the link "disabled link"
+      """

--- a/features/browser/radio_buttons.feature
+++ b/features/browser/radio_buttons.feature
@@ -38,3 +38,10 @@ Feature: Radio Buttons
   Scenario: User can select 2nd radio button with the same name
     Given I select the "2nd" radio button "blue" if it is not selected
      Then I should see the "2nd" radio button "blue" is selected
+
+  Scenario: User can not select a disabled radio button
+    Given I should see the radio button "red" is disabled
+      And I expect the following step to fail with "unable to select the radio button, as it is disabled"
+      """
+      Then I select the radio button "red"
+      """

--- a/src/cucu/steps/base_steps.py
+++ b/src/cucu/steps/base_steps.py
@@ -31,7 +31,10 @@ def is_disabled(element):
     """
     internal method to check an element is disabled
     """
-    return element.get_attribute("disabled")
+    return (
+        element.get_attribute("disabled")
+        or element.get_attribute("aria-disabled") == "true"
+    )
 
 
 def is_not_disabled(element):

--- a/src/cucu/steps/button_steps.py
+++ b/src/cucu/steps/button_steps.py
@@ -58,6 +58,11 @@ def click_button(ctx, button):
     """
     internal method used to simply click a button element
     """
+    ctx.check_browser_initialized()
+
+    if base_steps.is_disabled(button):
+        raise RuntimeError("unable to click the button, as it is disabled")
+
     ctx.browser.click(button)
 
 

--- a/src/cucu/steps/checkbox_steps.py
+++ b/src/cucu/steps/checkbox_steps.py
@@ -57,6 +57,9 @@ def check_checkbox(ctx, checkbox):
     if is_checked(checkbox):
         raise Exception("checkbox already checked")
 
+    if base_steps.is_disabled(checkbox):
+        raise RuntimeError("unable to check the checkbox, as it is disabled")
+
     ctx.browser.click(checkbox)
 
 

--- a/src/cucu/steps/dropdown_steps.py
+++ b/src/cucu/steps/dropdown_steps.py
@@ -93,6 +93,11 @@ def find_n_select_dropdown_option(ctx, dropdown, option):
 
     dropdown_element = find_dropdown(ctx, dropdown)
 
+    if base_steps.is_disabled(dropdown_element):
+        raise RuntimeError(
+            "unable to select from the dropdown, as it is disabled"
+        )
+
     if dropdown_element.tag_name == "select":
         select_element = Select(dropdown_element)
         select_element.select_by_visible_text(option)

--- a/src/cucu/steps/input_steps.py
+++ b/src/cucu/steps/input_steps.py
@@ -62,6 +62,10 @@ def find_n_write(ctx, name, value, index=0):
     ctx.check_browser_initialized()
 
     input_ = find_input(ctx, name, index=index)
+
+    if base_steps.is_disabled(input_):
+        raise RuntimeError("unable to write into the input, as it is disabled")
+
     input_.clear()
     input_.send_keys(value)
 
@@ -81,6 +85,10 @@ def find_n_clear(ctx, name, index=0):
     ctx.check_browser_initialized()
 
     input_ = find_input(ctx, name, index=index)
+
+    if base_steps.is_disabled(input_):
+        raise RuntimeError("unable to clear the input, as it is disabled")
+
     input_.clear()
 
 

--- a/src/cucu/steps/link_steps.py
+++ b/src/cucu/steps/link_steps.py
@@ -27,6 +27,10 @@ def click_link(ctx, link):
     internal method to click a link
     """
     ctx.check_browser_initialized()
+
+    if base_steps.is_disabled(link):
+        raise RuntimeError("unable to click the link, as it is disabled")
+
     ctx.browser.click(link)
 
 

--- a/src/cucu/steps/radio_steps.py
+++ b/src/cucu/steps/radio_steps.py
@@ -70,6 +70,11 @@ def find_n_select_radio_button(ctx, name, index=0, ignore_if_selected=False):
     ctx.check_browser_initialized()
     radio = find_n_assert_radio_button(ctx, name, index=index)
 
+    if base_steps.is_disabled(radio):
+        raise RuntimeError(
+            "unable to select the radio button, as it is disabled"
+        )
+
     selected = radio.get_attribute("checked") == "true"
 
     if selected:
@@ -100,6 +105,12 @@ def select_radio_button(ctx, radiobox):
     internal method to select a radio button that isn't already selected
     """
     ctx.check_browser_initialized()
+
+    if base_steps.is_disabled(radiobox):
+        raise RuntimeError(
+            "unable to select the radio button, as it is disabled"
+        )
+
     selected = bool(radiobox.get_attribute("checked"))
 
     if selected:

--- a/src/cucu/steps/tab_steps.py
+++ b/src/cucu/steps/tab_steps.py
@@ -23,6 +23,10 @@ def click_tab(ctx, tab):
     internal method to click a tab
     """
     ctx.check_browser_initialized()
+
+    if base_steps.is_disabled(tab):
+        raise RuntimeError("unable to click the tab, as it is disabled")
+
     ctx.browser.click(tab)
 
 


### PR DESCRIPTION
* we were not correctly handling HTML elements that are marked as `disabled` by throw an error when the test attempts to click, check, select, etc. the element. this fixes that and introduces a few tests to get the necessary test coverage.