### PR TITLE
fix snafu with frame switching

### DIFF
--- a/features/browser/frames.feature
+++ b/features/browser/frames.feature
@@ -22,3 +22,8 @@ Feature: Frames
 
   Scenario: User can see images in iframes
      Then I should see the image with the alt text "Stars"
+
+  Scenario: User can see multiple things across iframes
+     When I write "some text" into the input "input type=text"
+     Then I should see "some text" in the input "input type=text"
+      And I should see the image with the alt text "Stars"

--- a/src/cucu/browser/frames.py
+++ b/src/cucu/browser/frames.py
@@ -11,6 +11,8 @@ def search_in_all_frames(browser, search_function):
     result = search_function()
 
     if result is None:
+        # switch to default frame before getting the list of iframes
+        browser.switch_to_default_frame()
         frames = browser.execute('return document.querySelectorAll("iframe");')
         for frame in frames:
             #


### PR DESCRIPTION
* basically by not switching to the default frame to start before attempting to get the list of frames we could find ourselves stuck inside a frame context and see "no frames" currently on the page.