### PR TITLE
[QE-5321] Add CircleCI job to publish to private PyPI repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,20 @@ jobs:
       - store_artifacts:
           path: report/
 
+  publish:
+    docker:
+      - image: cimg/python:3.9.7
+    steps:
+      - checkout
+      - install_cucu_dependencies
+      - build_cucu_python_package
+      - run:
+          name: Publish to private PyPI repository
+          command: |
+            poetry config repositories.private ${PUBLISH_REPOSITORY}
+            poetry config http-basic.private ${PUBLISH_USERNAME} ${PUBLISH_PASSWORD}
+            poetry publish -r private
+
 workflows:
   build-n-test:
     jobs:
@@ -175,3 +189,12 @@ workflows:
       - test:
           name: test-firefox
           browser: firefox
+      - publish:
+          filters:
+            branches:
+              only: main
+          requires:
+            - pre-commit
+            - test-chrome
+            - test-edge
+            - test-firefox


### PR DESCRIPTION
This change adds a job to the CircleCI workflow that publishes cucu to our private PyPI repository on JFrog. I use poetry to publish. Right now, it does this on every commit to the `main` branch. Using an unreleased version is "at your own risk." It uses three environment variables set at the project level in CircleCI to configure the private repository URL and credentials. These are `PUBLISH_REPOSITORY`, `PUBLISH_USERNAME` and `PUBLISH_PASSWORD`. We could in theory switch to another vendor in the future, as long as they supported PyPI-compatible repositories.

Testing done:

I changed the branch name from `main` to my branch and made sure that the "publish" job ran. I then logged in to the JFrog UI and made sure the artifacts existed. I also verified that when I changed the branch back to `main`, the publish step did not run:

![Screen Shot 2022-10-13 at 1 36 40 PM](https://user-images.githubusercontent.com/72531030/195673354-ae18fc65-8a90-4bbb-9c1d-a057b3dfc05e.png)

![Screen Shot 2022-10-13 at 1 35 14 PM](https://user-images.githubusercontent.com/72531030/195673356-01c782dd-7092-4aaa-9224-00ddd4cd1861.png)

Note: there is a follow-up story https://dominodatalab.atlassian.net/browse/QE-9307 to limit publishing to when the version changes.

Jira link:

https://dominodatalab.atlassian.net/browse/QE-9044