### PR TITLE
fix the page load checks ordering

### DIFF
--- a/features/browser/buttons.feature
+++ b/features/browser/buttons.feature
@@ -5,6 +5,7 @@ Feature: Buttons
   Background: HTML page with buttons
     Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
 
+  @wip
   Scenario: User can click a <button>
     Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/buttons.html"
      Then I should see no value in the input "value:"

--- a/features/browser/page_checks.feature
+++ b/features/browser/page_checks.feature
@@ -2,6 +2,7 @@ Feature: Page checks
   As a developer I want to make sure that our built in page checks report errors
   accordingly
 
+  @wip
   Scenario: User will get an error from the readyState page checker if the page never finishes loading
     Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
       And I set the variable "CUCU_STEP_WAIT_TIMEOUT_S" to "5"
@@ -26,7 +27,7 @@ Feature: Page checks
 
         Scenario: That loads a page with broken images
           Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
-           And I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/broken_images.html"
+            And I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/broken_images.html"
       """
      Then I run the command "cucu run {CUCU_RESULTS_DIR}/broken_image_checker/broken_images.feature.feature --results {CUCU_RESULTS_DIR}/broken_image_checker_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
       And I should see "{STDOUT}" contains the following:
@@ -63,3 +64,39 @@ Feature: Page checks
     Given I start a webserver at directory "data/www/" and save the port to the variable "PORT"
       And I set the variable "CUCU_BROKEN_IMAGES_PAGE_CHECK" to "disabled"
      Then I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/broken_images.html"
+
+  Scenario: User gets expected order on page checks due to order of insertion
+    Given I create a file at "{CUCU_RESULTS_DIR}/ordered_page_checks/environment.py" with the following:
+      """
+      from cucu.environment import *
+      from cucu import register_page_check_hook
+
+      def wait_for_my_own_page_check(_):
+        pass
+
+      register_page_check_hook("my own page check", wait_for_my_own_page_check)
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/ordered_page_checks/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/ordered_page_checks/just_a_feature.feature" with the following:
+      """
+      Feature: Just a feature
+
+        Scenario: That opens a web page
+          Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+            And I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/buttons.html"
+      """
+     Then I run the command "cucu run {CUCU_RESULTS_DIR}/ordered_page_checks/just_a_feature.feature --results {CUCU_RESULTS_DIR}/ordered_page_checks_results -l debug" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      And I should see "{STDOUT}" matches the following:
+      """
+      [\s\S]*
+      .* DEBUG executing page check "wait for document.readyState"
+      .* DEBUG executed page check "wait for document.readyState" in .*
+      .* DEBUG executing page check "broken image checker"
+      .* DEBUG executed page check "broken image checker" in .*
+      .* DEBUG executing page check "my own page check"
+      .* DEBUG executed page check "my own page check" in .*
+      [\s\S]*
+      """

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -191,6 +191,7 @@ class Selenium(Browser):
             raise Exception(f"unknown browser {browser}")
 
         self.driver.set_window_size(width, height)
+        self.wait_for_page_to_load()
 
     def get_log(self):
         if config.CONFIG["CUCU_BROWSER"] == "firefox":
@@ -214,6 +215,7 @@ class Selenium(Browser):
             raise RuntimeError("no next browser tab available")
 
         self.driver.switch_to.window(window_handles[window_handle_index + 1])
+        self.wait_for_page_to_load()
 
     def switch_to_previous_tab(self):
         window_handles = self.driver.window_handles
@@ -224,6 +226,7 @@ class Selenium(Browser):
             raise RuntimeError("no previous browser tab available")
 
         self.driver.switch_to.window(window_handles[window_handle_index - 1])
+        self.wait_for_page_to_load()
 
     def back(self):
         self.driver.back()

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -5,6 +5,7 @@ import sys
 
 from cucu import behave_tweaks
 from cucu import init_global_hook_variables
+from cucu.page_checks import init_page_checks
 from behave.__main__ import main as behave_main
 from datetime import datetime
 
@@ -38,6 +39,7 @@ def behave(
     redirect_output=False,
 ):
     init_global_hook_variables()
+    init_page_checks()
 
     if not dry_run:
         write_run_details(results, filepath)

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -30,6 +30,7 @@ CONFIG.define(
 )
 
 init_global_hook_variables()
+init_page_checks()
 
 
 def escape_filename(string):
@@ -70,7 +71,6 @@ def before_scenario(ctx, scenario):
     # values and not really bleed values between scenario runs
     CONFIG.restore()
     init_scenario_hook_variables()
-    init_page_checks()
 
     ctx.scenario = scenario
     ctx.step_index = 0

--- a/src/cucu/hooks.py
+++ b/src/cucu/hooks.py
@@ -1,5 +1,6 @@
 import re
 
+from collections import OrderedDict
 from cucu.config import CONFIG
 
 CONFIG.define(
@@ -21,7 +22,7 @@ def init_global_hook_variables():
     CONFIG["__CUCU_BEFORE_STEP_HOOKS"] = []
     CONFIG["__CUCU_AFTER_STEP_HOOKS"] = []
 
-    CONFIG["__CUCU_PAGE_CHECK_HOOKS"] = {}
+    CONFIG["__CUCU_PAGE_CHECK_HOOKS"] = OrderedDict()
     CONFIG["__CUCU_HTML_REPORT_TAG_HANDLERS"] = {}
 
     CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"] = []


### PR DESCRIPTION
* it should at least gaurantee to call your page checks in the order by which you inserted them.

* also snuck in wait_for_page_loading when switching between tabs