### PR TITLE
[QE-9244] Update stack trace text to make path less specific

### DIFF
--- a/features/cli/internals.feature
+++ b/features/cli/internals.feature
@@ -7,7 +7,7 @@ Feature: Internals
      Then I should see "{STDOUT}" matches the following:
       """
       [\s\S]*
-      .*File ".*\/src\/cucu\/steps\/text_steps.py", line 28, in \<module\>
+      .*File ".*\/cucu\/steps\/text_steps.py", line 28, in \<module\>
       [\s\S]*
       """
 


### PR DESCRIPTION
The problem: If you run the cucu integration tests with `cucu run` instead of `poetry run cucu run`, the paths are different and the stack trace fails

The solution: remove the leading `/src` from the path.

This is needed so we can test that the installed version of cucu is working in the base standalone Domino cucu docker container.

Jira story: https://dominodatalab.atlassian.net/browse/QE-9044