### PR TITLE
better support for large text entry

### DIFF
--- a/features/browser/inputs_limits.feature
+++ b/features/browser/inputs_limits.feature
@@ -1,0 +1,32 @@
+Feature: Inputs Limits
+  As a developer I want to make sure that inputs can be interacted with while
+  pushing the limits of what the browser and framework can handle.
+
+  Scenario: User can write into an input
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      # create a file with 4KB
+      And I run the following script and expect exit code "0":
+      """
+      yes "" | tr "\n" "X" | dd of={CUCU_RESULTS_DIR}/input_data.txt bs=1024 count=4
+      """
+      And I read the contents of the file at "{CUCU_RESULTS_DIR}/input_data.txt" and save to the variable "DATA"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
+     Then I should see no value in the input "input type=text"
+     When I write "{DATA}" into the input "input type=text"
+     Then I should see the previous step took less than "1" seconds
+      And I should see "input type=text was modified" in the input "last touched input"
+      And I should see "{DATA}" in the input "input type=text"
+
+  Scenario: User can write into a textarea
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      # create a file with 4KB
+      And I run the following script and expect exit code "0":
+      """
+      yes "" | tr "\n" "X" | dd of={CUCU_RESULTS_DIR}/input_data.txt bs=1024 count=4
+      """
+      And I read the contents of the file at "{CUCU_RESULTS_DIR}/input_data.txt" and save to the variable "DATA"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
+     Then I should see no value in the input "textarea with label"
+     When I write "{DATA}" into the input "textarea with label"
+     Then I should see the previous step took less than "1" seconds
+      And I should see "textarea with label was modified" in the input "last touched input"

--- a/src/cucu/steps/command_steps.py
+++ b/src/cucu/steps/command_steps.py
@@ -160,3 +160,11 @@ def run_script_and_check_exit_code(context, stdout_var, stderr_var, exit_code):
         stderr_var=stderr_var,
         check_exit_code=exit_code,
     )
+
+
+@step('I run the following script and expect exit code "{exit_code}"')
+def run_script_and_expect_exit_code(context, exit_code):
+    run_script(
+        context.text,
+        check_exit_code=exit_code,
+    )

--- a/src/cucu/steps/input_steps.py
+++ b/src/cucu/steps/input_steps.py
@@ -67,7 +67,23 @@ def find_n_write(ctx, name, value, index=0):
         raise RuntimeError("unable to write into the input, as it is disabled")
 
     input_.clear()
-    input_.send_keys(value)
+
+    if len(value) > 512:
+        #
+        # to avoid various bugs with writing large chunks of text into
+        # inputs/textareas using send_keys we can just put the text into the
+        # @value attribute and simulate a keystroke so other UI related events
+        # fire, list of some bugs:
+        #
+        #  * https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/4469
+        #  * various stackoverflow articles on this matter
+        #
+        ctx.browser.execute("arguments[0].value = arguments[1];", input_, value)
+        input_.send_keys(" ")
+        input_.send_keys(Keys.BACKSPACE)
+
+    else:
+        input_.send_keys(value)
 
 
 def find_n_clear(ctx, name, index=0):


### PR DESCRIPTION
* there are a few bugs when using send_keys to send large blocks of text so we could benefit from a workaround when anyone attempts to send more than 512 bytes of text (arbitrary number chosen).