### PR TITLE
Implement a step for checking merely whether a regex is present

### DIFF
--- a/features/browser/text.feature
+++ b/features/browser/text.feature
@@ -48,3 +48,13 @@ Feature: Text
     Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/text.html"
      Then I should see the text "just some text in a textarea"
+
+  Scenario: User can see text that matches a regex
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/text.html"
+     Then I should see text matching the regex "just.*a.l[abcd]bel" on the current page
+
+  Scenario: User can see text that matches a regex with nested tags
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/text.html"
+     Then I should see text matching the regex "text with n.st.d" on the current page

--- a/src/cucu/steps/step_utils.py
+++ b/src/cucu/steps/step_utils.py
@@ -3,6 +3,16 @@ import re
 from cucu import config
 
 
+def search(regex, value):
+    """
+    search for a matching regex within the value provided.
+    """
+    match = re.search(regex, value)
+
+    if match is None:
+        raise RuntimeError(f'"{regex}" did not match anything in "{value}"')
+
+
 def search_and_save(regex, value, name, variable):
     """
     search for a matching regex within the value provided and then save the value

--- a/src/cucu/steps/text_steps.py
+++ b/src/cucu/steps/text_steps.py
@@ -54,7 +54,7 @@ def match_for_regex_to_page_and_save(ctx, regex, name, variable):
 
 
 @step(
-    'I should see the regex "{regex}" on the current page'
+    'I should see text matching the regex "{regex}" on the current page'
 )
 def search_for_regex_to_page_and_save(ctx, regex, name, variable):
     ctx.check_browser_initialized()

--- a/src/cucu/steps/text_steps.py
+++ b/src/cucu/steps/text_steps.py
@@ -51,3 +51,15 @@ def match_for_regex_to_page_and_save(ctx, regex, name, variable):
         'return jQuery("body").children(":visible").text();'
     )
     step_utils.match_and_save(regex, text, name, variable)
+
+
+@step(
+    'I should see the regex "{regex}" on the current page'
+)
+def search_for_regex_to_page_and_save(ctx, regex, name, variable):
+    ctx.check_browser_initialized()
+    ctx.browser.execute(load_jquery_lib())
+    text = ctx.browser.execute(
+        'return jQuery("body").children(":visible").text();'
+    )
+    step_utils.search(regex, text)

--- a/src/cucu/steps/text_steps.py
+++ b/src/cucu/steps/text_steps.py
@@ -56,7 +56,7 @@ def match_for_regex_to_page_and_save(ctx, regex, name, variable):
 @step(
     'I should see text matching the regex "{regex}" on the current page'
 )
-def search_for_regex_to_page_and_save(ctx, regex, name, variable):
+def search_for_regex_on_page(ctx, regex):
     ctx.check_browser_initialized()
     ctx.browser.execute(load_jquery_lib())
     text = ctx.browser.execute(

--- a/src/cucu/steps/text_steps.py
+++ b/src/cucu/steps/text_steps.py
@@ -53,9 +53,7 @@ def match_for_regex_to_page_and_save(ctx, regex, name, variable):
     step_utils.match_and_save(regex, text, name, variable)
 
 
-@step(
-    'I should see text matching the regex "{regex}" on the current page'
-)
+@step('I should see text matching the regex "{regex}" on the current page')
 def search_for_regex_on_page(ctx, regex):
     ctx.check_browser_initialized()
     ctx.browser.execute(load_jquery_lib())


### PR DESCRIPTION
We have steps for matching text on the page and extracting match groups, however we don't have a step which will just search for text on the page and fail if it is not present.  This PR adds such a step.