### PR TITLE
expanding the frame switching code to other methods

### DIFF
--- a/data/www/buttons.html
+++ b/data/www/buttons.html
@@ -24,6 +24,8 @@
 
     <button onclick="update('disabled button');" disabled>disabled button</button>
     <button onclick="update('aria-disabled button');" aria-disabled="true">aria-disabled button</button>
+
+    <button id="button-with-child" onclick="update('button with inner child label');"><label>button with inner child label</label></button><br/>
   </body>
   </body>
 

--- a/features/cli/internals.feature
+++ b/features/cli/internals.feature
@@ -91,3 +91,15 @@ Feature: Internals
           Given I should see "\{FOO\}" is empty
       """
      Then I run the command "cucu run {CUCU_RESULTS_DIR}/variable_bleed/bleed.feature --results {CUCU_RESULTS_DIR}/variable_bleed_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+
+  @custom
+  Scenario: User can define a custom step which uses direct WebElement find methods
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/buttons.html"
+     Then I should see the element with id "button-with-child" has a child
+
+  @custom
+  Scenario: User can define a custom step which uses direct WebElement find methods across iframes
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/frames.html"
+     Then I should see the element with id "button-with-child" has a child

--- a/features/cli/lint.feature
+++ b/features/cli/lint.feature
@@ -263,7 +263,6 @@ Feature: Lint
 
       """
 
-
   @regression
   Scenario: User can lint and fix a file with no indentation
     Given I create a file at "{CUCU_RESULTS_DIR}/no_indent/environment.py" with the following:
@@ -386,7 +385,6 @@ Feature: Lint
      Then I run the command "cucu lint {CUCU_RESULTS_DIR}/custom_linting_with_exclusions/custom_linting_feature.feature" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
       And I should see "{STDOUT}" is empty
       And I should see "{STDERR}" is empty
-
 
   Scenario: User gets appropriate exit code when cucu can not parse the file
     Given I create a file at "{CUCU_RESULTS_DIR}/broken_feature_file_lint/environment.py" with the following:

--- a/features/steps/cucu_steps.py
+++ b/features/steps/cucu_steps.py
@@ -1,2 +1,12 @@
 # only thing your project requires to load cucu steps
 import cucu.steps
+
+from cucu import step
+from selenium.webdriver.common.by import By
+
+
+@step('I should see the element with id "{id}" has a child')
+def should_see_the_element_with_id_has_a_child(ctx, id):
+    ctx.check_browser_initialized()
+    element = ctx.browser.css_find_elements(f"*[id={id}]")[0]
+    child = element.find_elements(By.CSS_SELECTOR, "*")[0]

--- a/src/cucu/__init__.py
+++ b/src/cucu/__init__.py
@@ -3,9 +3,11 @@ __version__ = "0.1.0"
 
 import sys
 from cucu import behave_tweaks
+from cucu.browser import selenium_tweaks
 
 # intercept the stdout/stderr so we can do things such as hiding secrets in logs
 behave_tweaks.init_step_hooks(sys.stdout, sys.stderr)
+selenium_tweaks.init()
 
 from cucu.hooks import (
     init_global_hook_variables,

--- a/src/cucu/browser/frames.py
+++ b/src/cucu/browser/frames.py
@@ -10,7 +10,7 @@ def search_in_all_frames(browser, search_function):
     """
     result = search_function()
 
-    if result is None:
+    if not result:
         # switch to default frame before getting the list of iframes
         browser.switch_to_default_frame()
         frames = browser.execute('return document.querySelectorAll("iframe");')
@@ -24,7 +24,7 @@ def search_in_all_frames(browser, search_function):
             browser.switch_to_frame(frame)
             result = search_function()
 
-            if result is not None:
+            if result:
                 return result
 
     return result

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -4,6 +4,7 @@ import logging
 import urllib3
 
 from cucu.browser.core import Browser
+from cucu.browser.frames import search_in_all_frames
 from cucu import config, logger
 from cucu import edgedriver_autoinstaller
 
@@ -238,12 +239,15 @@ class Selenium(Browser):
         return self.driver.title
 
     def css_find_elements(self, selector):
-        elements = self.driver.find_elements(By.CSS_SELECTOR, selector)
+        def find_elements_in_frame():
+            elements = self.driver.find_elements(By.CSS_SELECTOR, selector)
 
-        def visible(element):
-            return element.is_displayed()
+            def visible(element):
+                return element.is_displayed()
 
-        return list(filter(visible, elements))
+            return list(filter(visible, elements))
+
+        return search_in_all_frames(self, find_elements_in_frame)
 
     def execute(self, javascript, *args):
         return self.driver.execute_script(javascript, *args)

--- a/src/cucu/browser/selenium_tweaks.py
+++ b/src/cucu/browser/selenium_tweaks.py
@@ -1,0 +1,27 @@
+from cucu.config import CONFIG
+from cucu.browser.frames import search_in_all_frames
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote import webelement
+
+# monkey patch some methods at the WebElement level
+__ORIGINAL_FIND_ELEMENTS = webelement.WebElement.find_elements
+
+
+def init():
+    """
+    initialize various selenium tweaks to change the behavior of the underlying
+    selenium classes.
+    """
+
+    # intercept the find_elements calls and use the nifty frames method to allow
+    # the expression to be executed against every visible frame to find the
+    # desired element.
+    def find_elements(self, by="id", value=None):
+        ctx = CONFIG["__CUCU_CTX"]
+
+        def find_elements_in_frame():
+            return __ORIGINAL_FIND_ELEMENTS(self, by, value)
+
+        return search_in_all_frames(ctx.browser, find_elements_in_frame)
+
+    webelement.WebElement.find_elements = find_elements

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -51,6 +51,7 @@ def check_browser_initialized(ctx):
 
 
 def before_all(ctx):
+    CONFIG["__CUCU_CTX"] = ctx
     CONFIG.snapshot()
     ctx.check_browser_initialized = partial(check_browser_initialized, ctx)
 

--- a/src/cucu/steps/image_steps.py
+++ b/src/cucu/steps/image_steps.py
@@ -1,5 +1,4 @@
 from cucu import helpers, retry, step, fuzzy
-from cucu.browser.frames import search_in_all_frames
 
 
 def find_image(ctx, name, index=0):
@@ -20,17 +19,12 @@ def find_image(ctx, name, index=0):
     ctx.check_browser_initialized()
 
     name = name.replace('"', '\\"')
+    images = ctx.browser.css_find_elements(f'img[alt="{name}"')
 
-    def find_image_in_current_frame():
-        image = None
-        images = ctx.browser.css_find_elements(f'img[alt="{name}"')
+    if index >= len(images):
+        return None
 
-        if len(images) > index:
-            image = images[index]
-
-        return image
-
-    return search_in_all_frames(ctx.browser, find_image_in_current_frame)
+    return images[index]
 
 
 helpers.define_should_see_thing_with_name_steps(


### PR DESCRIPTION
* basically we want to be sure that any use of the various ways to find elements on the page through fuzzy, css_find_elements (on WebElement or cucu.browser.Browser object) all have the ability to switch through frames when searching for elements.