### PR TITLE
fixing the script running steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,14 @@ commands:
           name: install cucu dependencies
           command: pip install poetry && poetry install
 
+  install_test_dependencies: &install_test_dependencies
+    steps:
+      - run:
+          name: install test dependencies
+          command: |
+            apt-get update
+            apt-get install -y expect
+
   build_cucu_python_package: &build_cucu_python_package
     steps:
       - run:
@@ -130,6 +138,7 @@ jobs:
     steps:
       - checkout
       - install_cucu_dependencies
+      - install_test_dependencies
       - build_cucu_python_package
       - install_cucu_globally
       - setup_remote_docker_env

--- a/features/os/command_steps.feature
+++ b/features/os/command_steps.feature
@@ -5,3 +5,26 @@ Feature: Command steps
   Scenario: User can execute a command and use its output
     Given I run the command "echo -n foobar" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see "{STDOUT}" is equal to "foobar"
+
+  Scenario: User can execute an expect script
+    Given I create a file at "{CUCU_RESULTS_DIR}/interactive_script.sh" with the following
+      """
+      #!/bin/bash
+      echo "What's your name?"
+      read name
+      echo "What's your favorite color?"
+      read color
+      echo "$name likes the color $color"
+      """
+      And I run the command "chmod +x {CUCU_RESULTS_DIR}/interactive_script.sh" and expect exit code "0"
+     When I run the following script and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      """
+      #!/usr/bin/expect
+
+      spawn {CUCU_RESULTS_DIR}/interactive_script.sh
+      expect "What's your name?\r"
+      send -- "Peter\r"
+      expect "What's your favorite color?\r"
+      send -- "purple\r"
+      expect "Peter likes the color purple\r"
+      """

--- a/src/cucu/steps/command_steps.py
+++ b/src/cucu/steps/command_steps.py
@@ -1,3 +1,4 @@
+import atexit
 import os
 import shlex
 import subprocess
@@ -47,9 +48,17 @@ def run_script(
     exit_code_var=None,
     check_exit_code=None,
 ):
-    shell_command = os.environ.get("SHELL", "/bin/sh")
+    script_filename = os.path.abspath(f".cucu_run_script.{os.getpid()}.sh")
+    atexit.register(os.remove, script_filename)
+
+    with open(script_filename, "wb") as script_file:
+        script_file.write(script.encode())
+
+    os.chmod(script_filename, 0o755)
     process = subprocess.run(
-        [shell_command], capture_output=True, shell=True, input=script.encode()
+        [script_filename],
+        capture_output=True,
+        shell=True,
     )
 
     if exit_code_var:


### PR DESCRIPTION
* we had a bug when running a real script with a specific [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) as we weren't really writing out the script to execute it as a script but instead ingesting a bunch of commands through `STDIN` to the shell process.