### PR TITLE
[QE-9244] Add option to ignore SSL certificate errors

### DIFF
--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -61,6 +61,9 @@ class Selenium(Browser):
         height = config.CONFIG["CUCU_BROWSER_WINDOW_HEIGHT"]
         width = config.CONFIG["CUCU_BROWSER_WINDOW_WIDTH"]
         cucu_downloads_dir = config.CONFIG["CUCU_BROWSER_DOWNLOADS_DIR"]
+        ignore_ssl_certificate_errors = config.CONFIG[
+            "CUCU_IGNORE_SSL_CERTIFICATE_ERRORS"
+        ]
 
         if browser.startswith("chrome"):
             options = Options()
@@ -74,6 +77,9 @@ class Selenium(Browser):
 
             if headless:
                 options.add_argument("--headless")
+
+            if ignore_ssl_certificate_errors:
+                options.add_argument("ignore-certificate-errors")
 
             desired_capabilities = DesiredCapabilities.CHROME
             desired_capabilities["goog:loggingPrefs"] = {"browser": "ALL"}
@@ -114,6 +120,9 @@ class Selenium(Browser):
                 "browser.helperApps.neverAsk.saveToDisk",
                 "images/jpeg, application/pdf, application/octet-stream, text/plain",
             )
+
+            if ignore_ssl_certificate_errors:
+                profile.accept_untrusted_certs = True
 
             options.add_argument(f"--width={width}")
             options.add_argument(f"--height={height}")
@@ -160,9 +169,13 @@ class Selenium(Browser):
                 options.use_chromium = True
                 options.add_argument("--headless")
 
+            desired_capabilities = DesiredCapabilities.EDGE
+
+            if ignore_ssl_certificate_errors:
+                desired_capabilities["acceptSslCerts"] = True
+
             if selenium_remote_url is not None:
                 logger.debug(f"webdriver.Remote init: {selenium_remote_url}")
-                desired_capabilities = DesiredCapabilities.EDGE
                 try:
                     self.driver = webdriver.Remote(
                         command_executor=selenium_remote_url,
@@ -184,7 +197,9 @@ class Selenium(Browser):
                     edgedriver_autoinstaller.utils.download_edgedriver()
                 )
                 self.driver = webdriver.Edge(
-                    executable_path=edgedriver_filepath, options=options
+                    executable_path=edgedriver_filepath,
+                    options=options,
+                    capabilities=desired_capabilities,
                 )
 
         else:


### PR DESCRIPTION
# Problem

In order to fake external access to the deployment from inside the Kubernetes cluster for the Deployment Validation Tests, we need to set up a reverse proxy, simulating the load balancer with a self-signed SSL certificate. (We do not have access to the real certificate.) Tests will fail unless we ignore SSL certificate errors.

# Solution

Add a new option `CUCU_IGNORE_SSL_CERTIFICATE_ERRORS` and add the appropriate configuration options for Firefox, Edge, and Chrome.

# Testing Done

Tested with and without the option in CircleCI

https://app.circleci.com/pipelines/github/cerebrotech/cucu/1054/workflows/f220ac9c-215d-49a3-9641-03a362c454cb

https://app.circleci.com/pipelines/github/cerebrotech/cucu/1055/workflows/dbecaa0c-6b43-43b0-b3f4-3a58cd6b11a5

(I created a second branch with the environment variable enabled for the integration tests in the CircleCI job to test that configuration.)

The browser was able to launch successfully and all browser-based tests passed.

# Jira Link

https://dominodatalab.atlassian.net/browse/QE-9237