### PR TITLE
[QE-9244] Tagged release 0.93.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.92.0"
+version = "0.93.0"
 license = "MIT"
 description = ""
 authors = ["Rodney Gomes <rodneygomes@gmail.com>"]


### PR DESCRIPTION
# New features

* Add option to ignore SSL certificates

# Requirement

This is needed to spoof UI access to the deployment from within the Kubernetes cluster for the Deployment Validation Tests. We will be simulating the load balancer, using HTTPS termination with a self-signed certificate, and tests will fail unless we ignore certificate errors.

# Jira story

https://dominodatalab.atlassian.net/browse/QE-9237