### PR TITLE
fix leaked secrets in HTML test report

### DIFF
--- a/features/browser/console_logs.feature
+++ b/features/browser/console_logs.feature
@@ -17,6 +17,6 @@ Feature: Browser console logs
       .* "DEBUG", "message": ".*/console_logging.html 6:12 \\"this is a debug log\\"", .*
       .* "WARNING", "message": ".*/console_logging.html 7:12 \\"this is a warn log\\"", .*
       """
-      And I should see the file at "{CUCU_RESULTS_DIR}/console-logging/Feature with console logs/Scenario without console logs/logs/browser_console.log" has the following:
+      And I should see the file at "{CUCU_RESULTS_DIR}/console-logging/Feature with console logs/Scenario without console logs/logs/browser_console.log" is equal to the following:
       """
       """

--- a/features/browser/file_downloads.feature
+++ b/features/browser/file_downloads.feature
@@ -7,4 +7,4 @@ Feature: File downloads
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/files.html"
      When I click the link "download this file"
      Then I wait to see the downloaded file "file.txt"
-      And I wait to see the file at "{SCENARIO_DOWNLOADS_DIR}/file.txt"
+      And I wait to see a file at "{SCENARIO_DOWNLOADS_DIR}/file.txt"

--- a/features/cli/lint.feature
+++ b/features/cli/lint.feature
@@ -83,7 +83,7 @@ Feature: Lint
 
       """
 
-      And I should see the file at "{CUCU_RESULTS_DIR}/indent_lint/bad_feature_indentation.feature" has the following:
+      And I should see the file at "{CUCU_RESULTS_DIR}/indent_lint/bad_feature_indentation.feature" is equal to the following:
       """
       Feature: Badly indented feature
 
@@ -142,7 +142,7 @@ Feature: Lint
       linting errors found and fixed, see above for details
 
       """
-      And I should see the file at "{CUCU_RESULTS_DIR}/whitespace_lint/extraneous_whitespace.feature" has the following:
+      And I should see the file at "{CUCU_RESULTS_DIR}/whitespace_lint/extraneous_whitespace.feature" is equal to the following:
       """
       Feature: Feature with extraneous whitespace
 
@@ -289,7 +289,7 @@ Feature: Lint
       Then I echo "buzz"
       """
      Then I run the command "cucu lint --fix {CUCU_RESULTS_DIR}/no_indent/bad_feature_indentation.feature" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
-      And I should see the file at "{CUCU_RESULTS_DIR}/no_indent/bad_feature_indentation.feature" has the following:
+      And I should see the file at "{CUCU_RESULTS_DIR}/no_indent/bad_feature_indentation.feature" is equal to the following:
       """
       Feature: Badly indented feature
 

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -1,4 +1,4 @@
-@report
+  @report
 Feature: Report basics
   As a developer I want the user to be able to generate reports from tests runs
   in the most basic of situations

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -139,7 +139,7 @@ Feature: Run outputs
 
   Scenario: User gets JUnit XML results file as expected
     Given I run the command "cucu run data/features/feature_with_mixed_results.feature --results {CUCU_RESULTS_DIR}/validate_junit_xml_results" and save stdout to "STDOUT" and expect exit code "1"
-     Then I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Feature_with_mixed_results.xml"
+     Then I should see a file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Feature_with_mixed_results.xml"
       And I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Feature_with_mixed_results.xml" matches the following:
       """
       <testsuite name="Feature with mixed results" tests="5" errors="0" failures="2" skipped="1" timestamp=".*">

--- a/features/cli/run_with_junit.feature
+++ b/features/cli/run_with_junit.feature
@@ -4,9 +4,9 @@ Feature: Run with JUnit
 
   Scenario: User gets the JUnit XML files in the default location
     Given I run the command "cucu run data/features/echo.feature --results {CUCU_RESULTS_DIR}/run_with_default_junit_results --generate-report --report {CUCU_RESULTS_DIR}/run_with_default_junit_report" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
-     Then I should see the file at "{CUCU_RESULTS_DIR}/run_with_default_junit_results/TESTS-Echo.xml"
+     Then I should see a file at "{CUCU_RESULTS_DIR}/run_with_default_junit_results/TESTS-Echo.xml"
 
   Scenario: User gets the JUnit XML files in the custom location
     Given I run the command "cucu run data/features/echo.feature --junit {CUCU_RESULTS_DIR}/junit_files --results {CUCU_RESULTS_DIR}/run_with_custom_junit_results --generate-report --report {CUCU_RESULTS_DIR}/run_with_custom_junit_report" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
-      And I should not see the file at "{CUCU_RESULTS_DIR}/run_with_custom_junit_results/TESTS-Echo.xml"
-      And I should see the file at "{CUCU_RESULTS_DIR}/junit_files/TESTS-Echo.xml"
+      And I should not see a file at "{CUCU_RESULTS_DIR}/run_with_custom_junit_results/TESTS-Echo.xml"
+      And I should see a file at "{CUCU_RESULTS_DIR}/junit_files/TESTS-Echo.xml"

--- a/features/cli/run_with_workers.feature
+++ b/features/cli/run_with_workers.feature
@@ -13,4 +13,4 @@ Feature: Run with workers
   Scenario: User gets a report even when running with workesr
     Given I run the command "cucu run data/features/slow_features --workers 3 --generate-report --report {CUCU_RESULTS_DIR}/generate_report_with_workers_report --results {CUCU_RESULTS_DIR}/generate_report_with_workers_results" and save exit code to "EXIT_CODE"
       And I should see "{EXIT_CODE}" is equal to "0"
-     Then I should see the file at "{CUCU_RESULTS_DIR}/generate_report_with_workers_report/index.html"
+     Then I should see a file at "{CUCU_RESULTS_DIR}/generate_report_with_workers_report/index.html"

--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -9,7 +9,17 @@ Feature: Secrets
       """
       And I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/steps/__init__.py" with the following:
       """
+      from cucu import run_steps
       from cucu.steps import *
+
+      @step("I use a step with substeps that has secrets")
+      def step_with_substeps_that_has_secrets(context):
+          run_steps(
+              context,
+              \"\"\"
+          When I echo "super secret"
+          \"\"\",
+          )
       """
       And I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/cucurc.yml" with the following:
       """
@@ -25,10 +35,31 @@ Feature: Secrets
          Given I echo "the current user is \{USER\}"
            And I echo "\{MY_SECRET\}"
            And I echo "your home directory is at \{HOME\}"
+          Then I use a step with substeps that has secrets
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/features_with_secrets --results={CUCU_RESULTS_DIR}/features_with_secrets_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/features_with_secrets --results={CUCU_RESULTS_DIR}/features_with_secrets_results --generate-report --report={CUCU_RESULTS_DIR}/features_with_secrets_report" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" does not contain "super secret"
       And I should see "{STDOUT}" does not contain "another secret"
+      And I should see the file at "{CUCU_RESULTS_DIR}/features_with_secrets_results/run.json" does not contain the following:
+      """
+      super secret
+      """
+      And I should see the file at "{CUCU_RESULTS_DIR}/features_with_secrets_report/index.html" does not contain the following:
+      """
+      super secret
+      """
+      And I should see the file at "{CUCU_RESULTS_DIR}/features_with_secrets_report/Feature that spills the beans/This scenario prints some secrets to the logs/index.html" does not contain the following:
+      """
+      super secret
+      """
+      And I should see the file at "{CUCU_RESULTS_DIR}/features_with_secrets_report/Feature that spills the beans/This scenario prints some secrets to the logs/logs/cucu.debug.console.log" does not contain the following:
+      """
+      super secret
+      """
+      And I should see the file at "{CUCU_RESULTS_DIR}/features_with_secrets_report/Feature that spills the beans/This scenario prints some secrets to the logs/logs/cucu.debug.console.log.html" does not contain the following:
+      """
+      super secret
+      """
 
   Scenario: User can run a test while hiding secrets identified by the command line option
     Given I create a file at "{CUCU_RESULTS_DIR}/features_with_secrets/environment.py" with the following:
@@ -87,7 +118,7 @@ Feature: Secrets
            Then I pass the secret "\{MY_SECRET\}" to a substep
       """
      When I run the command "cucu run {CUCU_RESULTS_DIR}/substeps_without_variable_passthru --secrets MY_SECRET --results={CUCU_RESULTS_DIR}/substeps_without_variable_passthru_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
-     Then I should see the file at "{CUCU_RESULTS_DIR}/substeps_without_variable_passthru_results/Feature that spills the beans/This scenario prints some secrets to the logs/3 - I echo "super secret".png"
+     Then I should see a file at "{CUCU_RESULTS_DIR}/substeps_without_variable_passthru_results/Feature that spills the beans/This scenario prints some secrets to the logs/3 - I echo "super secret".png"
 
   Scenario: User gets expected behavior when using variable_passthru=True
     Given I create a file at "{CUCU_RESULTS_DIR}/substeps_with_variable_passthru/environment.py" with the following:
@@ -121,4 +152,4 @@ Feature: Secrets
            Then I pass the secret "\{MY_SECRET\}" to a substep
       """
      When I run the command "cucu run {CUCU_RESULTS_DIR}/substeps_with_variable_passthru --secrets MY_SECRET --results={CUCU_RESULTS_DIR}/substeps_with_variable_passthru_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
-     Then I should see the file at "{CUCU_RESULTS_DIR}/substeps_with_variable_passthru_results/Feature that spills the beans/This scenario prints some secrets to the logs/3 - I echo "\{MY_SECRET\}".png"
+     Then I should see a file at "{CUCU_RESULTS_DIR}/substeps_with_variable_passthru_results/Feature that spills the beans/This scenario prints some secrets to the logs/3 - I echo "\{MY_SECRET\}".png"

--- a/features/flow_control/run_after_scenario_steps.feature
+++ b/features/flow_control/run_after_scenario_steps.feature
@@ -4,8 +4,8 @@ Feature: Run after scenario hooks
 
   Scenario: User can use after scenario step to clean up files when the scenario passes
     Given I run the command "cucu run data/features/scenario_that_passes_with_after_scenario_steps.feature --results={CUCU_RESULTS_DIR}/passing_sceneario_with_after_steps_results" and expect exit code "0"
-     Then I should not see the file at "{CUCU_RESULTS_DIR}/delete-me.txt"
+     Then I should not see a file at "{CUCU_RESULTS_DIR}/delete-me.txt"
 
   Scenario: User can use after scenario step to clean up files when the scenario fails
     Given I run the command "cucu run data/features/scenario_that_fails_with_after_scenario_steps.feature --results={CUCU_RESULTS_DIR}/failing_sceneario_with_after_steps_results" and expect exit code "1"
-     Then I should not see the file at "{CUCU_RESULTS_DIR}/delete-me.txt"
+     Then I should not see a file at "{CUCU_RESULTS_DIR}/delete-me.txt"

--- a/features/os/file_steps.feature
+++ b/features/os/file_steps.feature
@@ -7,7 +7,7 @@ Feature: File steps
       """
       foobar
       """
-     Then I should see the file at "{CUCU_RESULTS_DIR}/create_file_test.txt" has the following
+     Then I should see the file at "{CUCU_RESULTS_DIR}/create_file_test.txt" is equal to the following
       """
       foobar
       """

--- a/features/os/screenshot.feature
+++ b/features/os/screenshot.feature
@@ -7,4 +7,4 @@ Feature: Screenshot
      When I set the variable "CUCU_MONITOR_PNG" to ".monitor.png"
       And I delete the file at "{CUCU_MONITOR_PNG}" if it exists
       And I should see the text "just some text in a label"
-     Then I should see the file at "{CUCU_MONITOR_PNG}"
+     Then I should see a file at "{CUCU_MONITOR_PNG}"

--- a/src/cucu/formatter/json.py
+++ b/src/cucu/formatter/json.py
@@ -12,6 +12,7 @@ import uuid
 
 from behave.formatter.base import Formatter
 from behave.model_core import Status
+from cucu import behave_tweaks
 
 
 # -----------------------------------------------------------------------------
@@ -30,7 +31,7 @@ class CucuJSONFormatter(Formatter):
     def __init__(self, stream_opener, config):
         super(CucuJSONFormatter, self).__init__(stream_opener, config)
         # -- ENSURE: Output stream is open.
-        self.stream = self.open()
+        self.stream = behave_tweaks.CucuOutputStream(self.open())
         self.feature_count = 0
         self.current_feature = None
         self.current_feature_data = None
@@ -211,6 +212,11 @@ class CucuJSONFormatter(Formatter):
             # -- FIRST FEATURE: Corner case when no features are provided.
             self.write_json_header()
         self.write_json_footer()
+        #
+        # HACK: avoid failing the strange assert in the base formatter class:
+        # https://github.com/behave/behave/blob/v1.2.6/behave/formatter/base.py#L186
+        #
+        self.stream = self.stream.stream
         self.close_stream()
 
     # -- JSON-DATA COLLECTION:

--- a/src/cucu/steps/filesystem_steps.py
+++ b/src/cucu/steps/filesystem_steps.py
@@ -50,23 +50,23 @@ def assert_file(ctx, filepath):
         raise RuntimeError(f"unable to see file at {filepath}")
 
 
-@step('I should see the file at "{filepath}"')
+@step('I should see a file at "{filepath}"')
 def should_see_file(ctx, filepath):
     assert_file(ctx, filepath)
 
 
-@step('I should not see the file at "{filepath}"')
+@step('I should not see a file at "{filepath}"')
 def should_not_see_file(ctx, filepath):
     if os.path.exists(filepath) and os.path.isfile(filepath):
         raise RuntimeError(f"able to see file at {filepath}")
 
 
-@step('I wait to see the file at "{filepath}"')
+@step('I wait to see a file at "{filepath}"')
 def wait_to_see_file(ctx, filepath):
     retry(assert_file)(ctx, filepath)
 
 
-@step('I wait up to "{seconds}" seconds to see the file at "{filepath}"')
+@step('I wait up to "{seconds}" seconds to see a file at "{filepath}"')
 def wait_up_to_see_file(ctx, seconds, filepath):
     seconds = float(seconds)
     retry(assert_file, wait_up_to_s=seconds)(ctx, filepath)
@@ -84,14 +84,25 @@ def should_not_see_directory(ctx, filepath):
         raise RuntimeError(f"able to see directory at {filepath}")
 
 
-@step('I should see the file at "{filepath}" has the following')
-def should_see_file_with_the_following(ctx, filepath):
+@step('I should see the file at "{filepath}" is equal to the following')
+def should_see_file_is_equal_to_the_following(ctx, filepath):
     with open(filepath, "rb") as input:
         file_contents = input.read().decode("utf8")
 
         if file_contents != ctx.text:
             raise RuntimeError(
-                f"expected:\n{ctx.text}\nbut got:\n{file_contents}\n"
+                f"\n{file_contents}\nis not equal to\n{ctx.text}\n"
+            )
+
+
+@step('I should see the file at "{filepath}" contains the following')
+def should_see_file_contains_the_following(ctx, filepath):
+    with open(filepath, "rb") as input:
+        file_contents = input.read().decode("utf8")
+
+        if not ctx.text in file_contents:
+            raise RuntimeError(
+                f"\n{file_contents}\ndoes not contain\n{ctx.text}\n"
             )
 
 
@@ -102,5 +113,32 @@ def should_see_file_matches_the_following(ctx, filepath):
 
         if not re.match(ctx.text, file_contents):
             raise RuntimeError(
-                f"expected:\n{ctx.text}\nbut got:\n{file_contents}\n"
+                f"\n{file_contents}\ndoes not match\n{ctx.text}\n"
             )
+
+
+@step('I should see the file at "{filepath}" is not equal to the following')
+def should_see_file_is_not_equal_to_the_following(ctx, filepath):
+    with open(filepath, "rb") as input:
+        file_contents = input.read().decode("utf8")
+
+        if file_contents != ctx.text:
+            raise RuntimeError(f"\n{file_contents}\nis equal to\n{ctx.text}\n")
+
+
+@step('I should see the file at "{filepath}" does not contain the following')
+def should_see_file_does_not_contain_the_following(ctx, filepath):
+    with open(filepath, "rb") as input:
+        file_contents = input.read().decode("utf8")
+
+        if ctx.text in file_contents:
+            raise RuntimeError(f"\n{file_contents}\ncontains\n{ctx.text}\n")
+
+
+@step('I should see the file at "{filepath}" does not match the following')
+def should_see_file_does_not_match_the_following(ctx, filepath):
+    with open(filepath, "rb") as input:
+        file_contents = input.read().decode("utf8")
+
+        if not re.match(ctx.text, file_contents):
+            raise RuntimeError(f"\n{file_contents}\nmatches\n{ctx.text}\n")


### PR DESCRIPTION
* this fixes leaking of secrets into the HTML test report as well as the underlying run.json file which was where the issues stemmed from.

* renamed some of the filesystem steps for consistency and readability.