### PR TITLE
adding before retry handlers

### DIFF
--- a/features/flow_control/before_retry_handlers.feature
+++ b/features/flow_control/before_retry_handlers.feature
@@ -1,0 +1,52 @@
+Feature: Before retry handlers
+  As a developer I want the test writers to be able to run before retry handler
+  code which can handle non-deterministic behavior of the underlying web
+  application under test.
+
+  Scenario: User can use before retry handler handle unexpected UI elements
+    Given I create a file at "{CUCU_RESULTS_DIR}/before_retry_handlers/environment.py" with the following:
+      """
+      from cucu.environment import *
+      from cucu import logger, register_before_retry_hook, run_steps
+      from cucu.steps import button_steps
+
+      def handle_the_button(ctx):
+        if ctx.browser:
+          button = button_steps.find_button(ctx, "buttons!")
+          if button:
+            button_steps.click_button(ctx, button)
+            logger.info("handled the pesky button buttons!")
+
+      register_before_retry_hook(handle_the_button)
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/before_retry_handlers/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/before_retry_handlers/feature_with_before_retry_handlers.feature" with the following:
+      """
+      Feature: Feature with scenarios using before retry handlers
+
+        Scenario: Scenario with an before retry handler
+          Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+            And I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/links.html"
+            # the before retry handler will be the one to click and switch to the next tab
+           Then I wait to see the button "button with child"
+      """
+     Then I run the command "cucu run {CUCU_RESULTS_DIR}/before_retry_handlers --results {CUCU_RESULTS_DIR}/before_retry_handlers_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      And I should see "{STDOUT}" matches the following
+      """
+      Feature: Feature with scenarios using before retry handlers
+
+        Scenario: Scenario with an before retry handler
+          Given I start a webserver at directory "data/www" and save the port to the variable "PORT" .*
+      .* INFO handled the pesky button buttons!
+            And I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/links.html" .*
+            [\s\S]*
+           Then I wait to see the button "button with child" .*
+
+      1 feature passed, 0 failed, 0 skipped
+      1 scenario passed, 0 failed, 0 skipped
+      3 steps passed, 0 failed, 0 skipped, 0 undefined
+      [\s\S]*
+      """

--- a/src/cucu/__init__.py
+++ b/src/cucu/__init__.py
@@ -21,6 +21,7 @@ from cucu.hooks import (
     register_custom_variable_handling,
     register_custom_tags_in_report_handling,
     register_custom_junit_failure_handler,
+    register_before_retry_hook,
 )
 
 from cucu.utils import (

--- a/src/cucu/hooks.py
+++ b/src/cucu/hooks.py
@@ -26,6 +26,8 @@ def init_global_hook_variables():
     CONFIG["__CUCU_HTML_REPORT_TAG_HANDLERS"] = {}
 
     CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"] = []
+    CONFIG["__CUCU_BEFORE_RETRY_HOOKS"] = []
+    CONFIG["__CUCU_CTX"] = None
 
 
 def init_scenario_hook_variables():
@@ -148,3 +150,20 @@ def register_custom_junit_failure_handler(handler):
           failure message in the JUnit XML results files.
     """
     CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"].append(handler)
+
+
+def register_before_retry_hook(hook_func):
+    """
+    register an before retry hook that will execute before retrying
+    cucu.utils.retry function call. The arguments passed to the provided hook
+    are only the current behave context object.
+
+    parameters:
+        handler(ctx): a method that accepts the current behave context and
+                      executes whatever it needs to before a retryable call is
+                      about to be retried.
+
+                      def handle(ctx):
+                        ctx.do_something()
+    """
+    CONFIG["__CUCU_BEFORE_RETRY_HOOKS"].append(hook_func)

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -85,6 +85,11 @@ def retry(func, wait_up_to_s=None, retry_after_s=None):
         retry=retry_if_not_exception_type(StopRetryException),
     )
     def new_decorator(*args, **kwargs):
+        ctx = CONFIG["__CUCU_CTX"]
+
+        for hook in CONFIG["__CUCU_BEFORE_RETRY_HOOKS"]:
+            hook(ctx)
+
         return func(*args, **kwargs)
 
     return new_decorator


### PR DESCRIPTION
* this allows for a few more lower level handling of when things are to be retried so fro example handling non deterministic appearance of popup/toast dialogs during a test run.