### PR TITLE
tagged release 0.99.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.98.0"
+version = "0.99.0"
 license = "MIT"
 description = ""
 authors = ["Rodney Gomes <rodneygomes@gmail.com>"]


### PR DESCRIPTION
changelog:
  * added `--runtime-timeout` flag for controlling how long a set of tests are executed for and aborting gracefully the run which can lead to cleaning reporting progress of previous tests that ran
  *  add new `register_before_retry_hook` for registering hooks into the retry mechanism used by various `I wait ...` steps where you can handle various non deterministic issues or inject actual code to handle other things such as errors that need you to open some dialog for the subsequent screenshot to capture the error details, etc.