### PR TITLE
produce dots when running with --workers

### DIFF
--- a/features/cli/report_with_custom_failure_handler.feature
+++ b/features/cli/report_with_custom_failure_handler.feature
@@ -33,6 +33,7 @@ Feature: Report with custom JUnit failure handler
       [\s\S]*
       """
 
+  @workers
   Scenario: User sees custom handler is not duplicated when running in parallel
     Given I create a file at "{CUCU_RESULTS_DIR}/custom_failure_handling_and_workers/environment.py" with the following:
       """

--- a/features/cli/run_with_workers.feature
+++ b/features/cli/run_with_workers.feature
@@ -1,16 +1,45 @@
+@workers
 Feature: Run with workers
   As a developer I want tests to be parallelized using workers and run as
   expected
 
   Scenario: User can parallelize a slow set of tests and speedup execution
-    Given I run the command "cucu run data/features/slow_features --results {CUCU_RESULTS_DIR}/slow_features_without_workers" and save exit code to "EXIT_CODE"
+    Given I run the command "cucu run data/features/slow_features --results {CUCU_RESULTS_DIR}/slow_features_without_workers" and expect exit code "0"
      Then I should see the previous step took more than "15" seconds
-      And I should see "{EXIT_CODE}" is equal to "0"
-     When I run the command "cucu run data/features/slow_features --workers 3 --results {CUCU_RESULTS_DIR}/slow_features_with_workers" and save exit code to "EXIT_CODE"
+     When I run the command "cucu run data/features/slow_features --workers 3 --results {CUCU_RESULTS_DIR}/slow_features_with_workers" and expect exit code "0"
      Then I should see the previous step took less than "10" seconds
-      And I should see "{EXIT_CODE}" is equal to "0"
 
   Scenario: User gets a report even when running with workesr
-    Given I run the command "cucu run data/features/slow_features --workers 3 --generate-report --report {CUCU_RESULTS_DIR}/generate_report_with_workers_report --results {CUCU_RESULTS_DIR}/generate_report_with_workers_results" and save exit code to "EXIT_CODE"
-      And I should see "{EXIT_CODE}" is equal to "0"
+    Given I run the command "cucu run data/features/slow_features --workers 3 --generate-report --report {CUCU_RESULTS_DIR}/generate_report_with_workers_report --results {CUCU_RESULTS_DIR}/generate_report_with_workers_results" and expect exit code "0"
      Then I should see a file at "{CUCU_RESULTS_DIR}/generate_report_with_workers_report/index.html"
+
+  Scenario: User gets only dots in the output when running with workers
+    Given I run the command "cucu run data/features/slow_features --workers 2 --results {CUCU_RESULTS_DIR}/dots_in_report_with_workers_results" and save stdout to "STDOUT" and expect exit code "0"
+     Then I should see "{STDOUT}" is equal to the following:
+     """
+     ...
+     """
+
+  Scenario: User gets progress even when a step is in a retry() block
+    Given I create a file at "{CUCU_RESULTS_DIR}/progress_when_in_retry/environment.py" with the following:
+      """
+      from cucu.environment import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/progress_when_in_retry/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/progress_when_in_retry/feature_with_wait_for_step.feature" with the following:
+      """
+      Feature: Feature with a failure
+
+        Scenario: Scenario that definitely fails
+          Given I wait to click the button "not there"
+      """
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/progress_when_in_retry --workers 2 --results {CUCU_RESULTS_DIR}/progress_when_in_retry_results" and save stdout to "STDOUT" and expect exit code "1"
+     Then I should see "{STDOUT}" contains the following:
+      # should contain more than 3 and given its a step that will retry for the
+      # 20s we're looking at 3 retries per second so easily 10's of dots
+      """
+      ............
+      """

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -338,7 +338,6 @@ def run(
                             ],
                             {
                                 "redirect_output": True,
-                                "log_start_n_stop": True,
                             },
                         )
                     )

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -186,6 +186,12 @@ def after_step(ctx, step):
     ctx.end_time = time.monotonic()
     ctx.previous_step_duration = ctx.end_time - ctx.start_time
 
+    # when set this means we're running in parallel mode using --workers and
+    # we want to see progress reported using simply dots
+    if CONFIG["__CUCU_PARENT_STDOUT"]:
+        CONFIG["__CUCU_PARENT_STDOUT"].write(".")
+        CONFIG["__CUCU_PARENT_STDOUT"].flush()
+
     # we only take screenshots of steps where there's a browser currently open
     # and this step has no substeps as in the reporting the substeps that
     # may actually do something on the browser take their own screenshots


### PR DESCRIPTION
* this is both better at showing there's actual progress as we will print a `.` per step or retry executed and for CI systems it gives feedback that the tests are not stuck doing nothing.