### PR TITLE
tagged release 0.101.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.100.0"
+version = "0.101.0"
 license = "MIT"
 description = ""
 authors = ["Rodney Gomes <rodneygomes@gmail.com>"]


### PR DESCRIPTION
changelog:
  * when running with `--workers` produce only `.` as progress for every step and retry executed.