### PR TITLE
few reporting fixes

### DIFF
--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -21,7 +21,7 @@ from cucu import (
 from cucu.browser import selenium
 from cucu.config import CONFIG
 from cucu.cli import thread_dumper
-from cucu.cli.run import behave, behave_init
+from cucu.cli.run import behave, behave_init, write_run_details
 from cucu.cli.steps import print_human_readable_steps, print_json_steps
 from cucu.lint import linter
 from importlib.metadata import version
@@ -239,6 +239,9 @@ def run(
 
     if junit is None:
         junit = results
+
+    if not dry_run:
+        write_run_details(results, filepath)
 
     try:
         if workers is None or workers == 1:

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -54,9 +54,6 @@ def behave(
 
     init_page_checks()
 
-    if not dry_run:
-        write_run_details(results, filepath)
-
     if color_output:
         os.environ["CUCU_COLOR_OUTPUT"] = str(color_output).lower()
 

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -7,6 +7,7 @@ import json
 import sys
 
 from ansi2html import Ansi2HTMLConverter
+from cucu import logger
 from cucu.config import CONFIG
 from xml.sax.saxutils import escape as escape_
 from urllib.parse import quote
@@ -53,7 +54,12 @@ def generate(results, basepath):
 
     for run_json_filepath in run_json_filepaths:
         with open(run_json_filepath, "rb") as index_input:
-            features += json.loads(index_input.read())
+            try:
+                features += json.loads(index_input.read())
+            except Exception as exception:
+                logger.warn(
+                    f"unable to read file {run_json_filepath}, got error: {exception}"
+                )
 
     # copy the external dependencies to the reports destination directory
     cucu_dir = os.path.dirname(sys.modules["cucu"].__file__)


### PR DESCRIPTION
* found bug when running with workers where every so often we'd end up with a blank `.run.json` file and the reporter doesn't handle it correctly and also the `run_details.json` should only be created once by the initial `cucu run` process otherwise we end up with an invalid JSON file when multiple workers would clobber each others writes to the file.