### PR TITLE
runtime exlusive resource locking

### DIFF
--- a/features/cli/run_with_exclusive_locks.feature
+++ b/features/cli/run_with_exclusive_locks.feature
@@ -1,0 +1,64 @@
+Feature: Run with exclusive locks
+  As a developer I want the user to be able have a way to make sure features
+  and scenarios can get exclusive locks to a resource using the tag @cucu:lock(...)
+  to obtain and release locks per scenario runs
+
+  Scenario: User can use exclusive locks per scenarios to guarantee exclusive access to some resource
+    Given I create a file at "{CUCU_RESULTS_DIR}/scenario_using_locks/environment.py" with the following:
+      """
+      from cucu.environment import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/scenario_using_locks/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/scenario_using_locks/first_feature_using_locks.feature" with the following:
+      """
+      Feature: First feature with scenarios using exclusive locks
+
+        @cucu:lock(port-20000)
+        Scenario: Scenario that requires exclusive lock to start a webserer on a specific port
+          Given I start a webserver at directory "\{CUCU_RESULTS_DIR\}/" on port "20000"
+           Then I sleep for "3" seconds
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/scenario_using_locks/second_feature_using_locks.feature" with the following:
+      """
+      Feature: Second feature with scenarios using exclusive locks
+
+        @cucu:lock(port-20000)
+        Scenario: Another scenario that requires exclusive lock to start a webserer on a specific port
+          Given I start a webserver at directory "\{CUCU_RESULTS_DIR\}/" on port "20000"
+           Then I sleep for "3" seconds
+      """
+     Then I run the command "cucu run {CUCU_RESULTS_DIR}/scenario_using_locks --workers 2 --results {CUCU_RESULTS_DIR}/scenario_using_locks_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      And I should see the previous step took more than "6" seconds
+
+  Scenario: User can use exclusive locks per feature to guarantee exclusive access to some resource
+    Given I create a file at "{CUCU_RESULTS_DIR}/feature_using_locks/environment.py" with the following:
+      """
+      from cucu.environment import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/feature_using_locks/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/feature_using_locks/first_feature_using_locks.feature" with the following:
+      """
+      @cucu:lock(port-20000)
+      Feature: First feature with scenarios using exclusive locks
+
+        Scenario: Scenario that requires exclusive lock to start a webserer on a specific port
+          Given I start a webserver at directory "\{CUCU_RESULTS_DIR\}/" on port "20000"
+           Then I sleep for "3" seconds
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/feature_using_locks/second_feature_using_locks.feature" with the following:
+      """
+      @cucu:lock(port-20000)
+      Feature: Second feature with scenarios using exclusive locks
+
+        Scenario: Another scenario that requires exclusive lock to start a webserer on a specific port
+          Given I start a webserver at directory "\{CUCU_RESULTS_DIR\}/" on port "20000"
+           Then I sleep for "3" seconds
+      """
+     Then I run the command "cucu run {CUCU_RESULTS_DIR}/feature_using_locks --workers 2 --results {CUCU_RESULTS_DIR}/feature_using_locks_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      And I should see the previous step took more than "6" seconds

--- a/poetry.lock
+++ b/poetry.lock
@@ -231,7 +231,7 @@ tests = ["rich", "littleutils", "pytest", "asttokens"]
 name = "filelock"
 version = "3.8.0"
 description = "A platform independent file lock."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -936,7 +936,7 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "2d4dac8979332f16fc41107d48f89fe9544d9624dcbea7db43debd64925de6b0"
+content-hash = "bd6ccd85dcaba475cb663098efe603fdeaaac291e35791c73a17dcc7195e30c0"
 
 [metadata.files]
 ansi2html = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ requests = "^2.27.1"
 beautifulsoup4 = "^4.11.1"
 ansi2html = "^1.7.0"
 jellyfish = "^0.9.0"
+filelock = "^3.8.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.3"

--- a/src/cucu/steps/webserver_steps.py
+++ b/src/cucu/steps/webserver_steps.py
@@ -11,10 +11,26 @@ class QuietHTTPRequestHandler(SimpleHTTPRequestHandler):
         return
 
 
+def start_webserver(directory, port=0):
+    handler = partial(QuietHTTPRequestHandler, directory=directory)
+    httpd = HTTPServer(("", int(port)), handler)
+
+    thread = Thread(target=httpd.serve_forever)
+    thread.start()
+    _, port = httpd.server_address
+
+    def shutdown_webserver(_):
+        httpd.shutdown()
+        thread.join()
+
+    register_after_this_scenario_hook(shutdown_webserver)
+    return port
+
+
 @step(
     'I start a webserver at directory "{directory}" and save the port to the variable "{variable}"'
 )
-def run_webserver_for_scenario(ctx, directory, variable):
+def run_webserver(ctx, directory, variable):
     """
     start a webserver with the root at the directory provided and save the
     port that the server is listening at to the variable name provided
@@ -23,16 +39,18 @@ def run_webserver_for_scenario(ctx, directory, variable):
         Given I start webserver at directory "/some/path" and save the port to the variable "PORT"
           And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/somefile.html"
     """
-    handler = partial(QuietHTTPRequestHandler, directory=directory)
-    httpd = HTTPServer(("", 0), handler)
-    thread = Thread(target=httpd.serve_forever)
-    thread.start()
-
-    _, port = httpd.server_address
+    port = start_webserver(directory)
     CONFIG[variable] = str(port)
 
-    def shutdown_webserver(_):
-        httpd.shutdown()
-        thread.join()
 
-    register_after_this_scenario_hook(shutdown_webserver)
+@step('I start a webserver at directory "{directory}" on port "{port}"')
+def run_webserver_on_port(ctx, directory, port):
+    """
+    start a webserver with the root at the directory provided and on the port
+    provided
+
+    examples:
+        Given I start webserver at directory "/some/path" on port "8888"
+          And I open a browser at the url "http://{HOST_ADDRESS}:8888/somefile.html"
+    """
+    start_webserver(directory, port=port)


### PR DESCRIPTION
* by using the tag `@cucu:lock(name)` one can make sure that other scenarios using the exact same name will only execute a scenario with the same lock name one at a time and avoid any runtime collisions.