### PR TITLE
fix periodic thread dumper when used with workers

### DIFF
--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -290,6 +290,7 @@ def run(
             else:
                 feature_filepaths = [filepath]
 
+            start = time.time()
             with multiprocessing.Pool(int(workers)) as pool:
                 if runtime_timeout:
                     logger.debug("setting up runtime timeout timer")
@@ -303,6 +304,7 @@ def run(
 
                         for child in multiprocessing.active_children():
                             os.kill(child.pid, signal.SIGINT)
+                            os.kill(child.pid, signal.SIGTERM)
 
                     timer = Timer(runtime_timeout, runtime_exit)
                     timer.start()
@@ -341,7 +343,6 @@ def run(
 
                 workers_failed = False
                 for result in async_results:
-                    result.wait(runtime_timeout)
                     exit_code = result.get(runtime_timeout)
                     if exit_code != 0:
                         workers_failed = True


### PR DESCRIPTION
* two small changes: * lets not wait for results after having waited for the multiprocess process to exit and simply do `get()` without a timeout * lets not `.join()` on the pool and instead we already called the `close()` and want to execute to remaining code which includes generating the test report and existing the thread dumper thread.