### PR TITLE
fix to runtime timeout option and how we terminate and exit when running with periodic thread dumper

### DIFF
--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -303,6 +303,7 @@ def run(
 
                         for child in multiprocessing.active_children():
                             os.kill(child.pid, signal.SIGINT)
+                            os.kill(child.pid, signal.SIGTERM)
 
                     timer = Timer(runtime_timeout, runtime_exit)
                     timer.start()
@@ -341,7 +342,6 @@ def run(
 
                 workers_failed = False
                 for result in async_results:
-                    result.wait(runtime_timeout)
                     exit_code = result.get(runtime_timeout)
                     if exit_code != 0:
                         workers_failed = True


### PR DESCRIPTION
* two small changes: * switch to a simple `.get(timeout)` instead of waiting to then do the `.get(...)` call. * send `SIGINT` followed by `SIGTERM` to the process which may result in broken *.-run.json files but truth is we want to exit now when the `--runtime-timeout` has been exceeded and not hope for things to clean up nicely.