### PR TITLE
fix issue with loading cucurc values when running with workers

### DIFF
--- a/features/cli/config.feature
+++ b/features/cli/config.feature
@@ -2,7 +2,7 @@ Feature: Config
   As a developer I want the user to get the expected variable and config
   behavior when using cucu
 
-  Scenario: User can load cucurc values from a cucucrc file in
+  Scenario: User can load cucurc values from cucurc files at various levels
     Given I create a file at "{CUCU_RESULTS_DIR}/load_nested_cucurc/environment.py" with the following:
       """
       from cucu.environment import *
@@ -33,6 +33,60 @@ Feature: Config
       """
      When I run the command "cucu run {CUCU_RESULTS_DIR}/load_nested_cucurc --results={CUCU_RESULTS_DIR}/nested_cucurc_results --env BUZZ=buzz" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following:
+       """
+       Feature: Feature file that prints some variables
+
+         Scenario: This scenario prints a bunch of variables
+       bar
+
+           Given I echo "\{FOO\}"      # .*
+           # FOO="bar"
+       booze
+
+             And I echo "\{FIZZ\}"     # .*
+             # FIZZ="booze"
+       buzz
+
+             And I echo "\{BUZZ\}"     # .*
+             # BUZZ="buzz"
+
+       1 feature passed, 0 failed, 0 skipped
+       1 scenario passed, 0 failed, 0 skipped
+       3 steps passed, 0 failed, 0 skipped, 0 undefined
+       [\s\S]*
+       """
+
+  Scenario: User can load cucurc values from cucurc files at various levels when using workers
+    Given I create a file at "{CUCU_RESULTS_DIR}/load_nested_cucurc_with_workers/environment.py" with the following:
+      """
+      from cucu.environment import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/load_nested_cucurc_with_workers/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/load_nested_cucurc_with_workers/cucurc.yml" with the following:
+      """
+      FOO: bar
+      FIZZ: booze
+      BUZZ: wah
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/load_nested_cucurc_with_workers/directory/cucurc.yml" with the following:
+      """
+      FIZZ: buzz
+      BUZZ: wat
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/load_nested_cucurc_with_workers/directory/feature_that_prints.feature" with the following:
+      """
+      Feature: Feature file that prints some variables
+
+        Scenario: This scenario prints a bunch of variables
+         Given I echo "\{FOO\}"
+           And I echo "\{FIZZ\}"
+           And I echo "\{BUZZ\}"
+      """
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/load_nested_cucurc_with_workers --results={CUCU_RESULTS_DIR}/nested_cucurc_with_workers_results --env BUZZ=buzz --workers 2" and expect exit code "0"
+     Then I should see the file at "{CUCU_RESULTS_DIR}/nested_cucurc_with_workers_results/feature_that_prints.log" matches the following:
        """
        Feature: Feature file that prints some variables
 

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -216,9 +216,6 @@ def run(
     init_global_hook_variables()
     dumper = None
 
-    # load all them configs
-    CONFIG.load_cucurc_files(filepath)
-
     if os.environ.get("CUCU") == "true":
         # when cucu is already running it means that we're running inside
         # another cucu process and therefore we should make sure the results

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -41,6 +41,9 @@ def behave(
     redirect_output=False,
     skip_init_global_hook_variables=False,
 ):
+    # load all them configs
+    CONFIG.load_cucurc_files(filepath)
+
     # general socket timeout instead of letting the framework ever get stuck on a
     # socket connect/read call
     timeout = float(CONFIG["CUCU_SOCKET_DEFAULT_TIMEOUT_S"])


### PR DESCRIPTION
* there's a sligthly snafu in the way we load and pass on the values when using `--workers` where the values aren't reliably propagated for custom variables