### PR TITLE
workers with runtime timeout

### DIFF
--- a/features/cli/run.feature
+++ b/features/cli/run.feature
@@ -76,8 +76,17 @@ Feature: Run
       """
 
   @runtime-timeout
-  Scenario: User can run with a runtime timeout and still exit without having hit the timeout
+  Scenario: User can run with a runtime timeout and exit without having hit the timeout
     Given I run the command "cucu run data/features/echo.feature --runtime-timeout 300 --results {CUCU_RESULTS_DIR}/runtime_timeout_results" and save stdout to "STDOUT" and expect exit code "0"
+     Then I should see the previous step took less than "5" seconds
+      And I should see "{STDOUT}" does not contain the following:
+      """
+      runtime timeout reached, aborting run
+      """
+
+  @runtime-timeout @workers
+  Scenario: User can run with a runtime timeout and workers and exit without having hit the timeout
+    Given I run the command "cucu run data/features/tagged_features --workers 2 --runtime-timeout 300 --results {CUCU_RESULTS_DIR}/runtime_timeout_with_workers_results" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see the previous step took less than "5" seconds
       And I should see "{STDOUT}" does not contain the following:
       """

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -321,6 +321,7 @@ def run(
                 feature_filepaths = [filepath]
 
             with multiprocessing.Pool(int(workers)) as pool:
+                timer = None
                 if runtime_timeout:
                     logger.debug("setting up runtime timeout timer")
 
@@ -375,6 +376,9 @@ def run(
                     exit_code = result.get(runtime_timeout)
                     if exit_code != 0:
                         workers_failed = True
+
+                if timer:
+                    timer.cancel()
 
                 pool.close()
                 pool.join()


### PR DESCRIPTION
* seems there is a real bug here where the workers processes can complete and we wouldn't actually get called to cancel the `Timer` from the after_all hook (could be an actual behave bug but I'll look into later)