### PR TITLE
QE-10164 Refactor method for clearing input

### DIFF
--- a/src/cucu/steps/input_steps.py
+++ b/src/cucu/steps/input_steps.py
@@ -65,12 +65,13 @@ def clear_input(input_):
     """
     input_.clear()
 
-    # Some specialized text inputs don't respond to the .clear() method,
-    # so we have to check if the input was properly cleared, and if there's
-    # anything left anything left, we delete it explicitly.
-    value_after_clear = input_.get_attribute("value")
-    if value_after_clear != "":
-        input_.send_keys(Keys.BACKSPACE * len(value_after_clear))
+    if input_.get_attribute("value") != "":
+        # Keys.CONTROL works on both laptops and through the Selenium grid;
+        # Keys.COMMAND works on laptop, but not on Selenium grid,
+        # and actually causes an active session on the grid to hang,
+        # so we can safely use only the Keys.CONTROL sequence.
+        input_.send_keys(Keys.CONTROL, "a")
+        input_.send_keys(Keys.BACKSPACE)
 
 
 def find_n_write(ctx, name, value, index=0):


### PR DESCRIPTION
I don't understand why, but the new method of clearing inputs is making the Selenium grid unhappy when dealing with certain inputs. The method introduced in this PR doesn't _seem_ like it has those same issues, but we should make sure to test the full suite of end-to-end tests with this approach to ensure that it doesn't happen to break something else.