### PR TITLE
QE-10656 fix huge images in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _Get your repo setup using cucu as a test framework_
 1. install and start Docker if you haven't already
 2. add cucu your `requirements.txt` to get from GH by label (use current label number)
    ```
-   git+ssh://git@github.com/cerebrotech/cucu@0.118.0#egg=cucu
+   git+ssh://git@github.com/cerebrotech/cucu@0.119.0#egg=cucu
    ```
 3. install it
    ```

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -62,12 +62,12 @@ Feature: Report basics
        | .*         | Feature with mixed results | 5     | 2      | 2      | 1       | failed | .*       |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
-      | Scenario                            | Total Steps | Status  | Duration |
-      | Scenario that fails                 | 2           | failed  | .*       |
-      | Scenario that has an undefined step | 1           | failed  | .*       |
-      | Scenario that passes                | 1           | passed  | .*       |
-      | Scenario that also passes           | 1           | passed  | .*       |
-      | Scenario that is skipped            | 1           | skipped | .*       |
+      | Started at | Scenario                            | Total Steps | Status  | Duration |
+      | .*         | Scenario that fails                 | 2           | failed  | .*       |
+      | .*         | Scenario that has an undefined step | 1           | failed  | .*       |
+      | .*         | Scenario that passes                | 1           | passed  | .*       |
+      | .*         | Scenario that also passes           | 1           | passed  | .*       |
+      | .*         | Scenario that is skipped            | 1           | skipped | .*       |
       And I click the button "Scenario that fails"
      Then I should see the text "RuntimeError: step fails on purpose"
      When I click the button "Index"
@@ -85,9 +85,9 @@ Feature: Report basics
        | .*         | Feature with background    | 2     | 1      | 0      | 1       | passed | .*       |
      When I click the button "Feature with background"
      Then I should see a table that matches the following:
-      | Scenario                            | Total Steps | Status  | Duration |
-      | Scenario which now has a background | 2           | passed  | .*       |
-      | Scenario that is skipped            | 2           | skipped | .*       |
+      | Started at | Scenario                            | Total Steps | Status  | Duration |
+      | .*         | Scenario which now has a background | 2           | passed  | .*       |
+      | .*         | Scenario that is skipped            | 2           | skipped | .*       |
 
   @workaround @QE-7075
   @disabled
@@ -140,13 +140,13 @@ Feature: Report basics
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      When I click the button "Slow feature #1"
      Then I should see a table that matches the following:
-      | Scenario      | Total Steps | Status | Duration |
-      | Slow scenario | 1           | .*     |    >*    |
+      | Started at | Scenario      | Total Steps | Status | Duration |
+      | .*         | Slow scenario | 1           | .*     |    >*    |
      When I go back on the browser
       And I click the button "Slow feature #2"
      Then I should see a table that matches the following:
-      | Scenario      | Total Steps | Status | Duration |
-      | Slow scenario | 1           | .*     |    >*    |
+      | Started at | Scenario      | Total Steps | Status | Duration |
+      | .*         | Slow scenario | 1           | .*     |    >*    |
 
   @show-skips
   Scenario: User can run results without skips in the HTML test report
@@ -158,12 +158,12 @@ Feature: Report basics
       | .*         | Feature with mixed results | 5     | 2      | 2      | 1       | failed | .*       |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
-      | Scenario                            | Total Steps | Status  | Duration |
-      | Scenario that fails                 | 2           | failed  | .*       |
-      | Scenario that has an undefined step | 1           | failed  | .*       |
-      | Scenario that passes                | 1           | passed  | .*       |
-      | Scenario that also passes           | 1           | passed  | .*       |
-      | Scenario that is skipped            | 1           | skipped | .*       |
+      | Started at | Scenario                            | Total Steps | Status  | Duration |
+      | .*         | Scenario that fails                 | 2           | failed  | .*       |
+      | .*         | Scenario that has an undefined step | 1           | failed  | .*       |
+      | .*         | Scenario that passes                | 1           | passed  | .*       |
+      | .*         | Scenario that also passes           | 1           | passed  | .*       |
+      | .*         | Scenario that is skipped            | 1           | skipped | .*       |
       And I click the button "Scenario that fails"
      Then I should see the text "RuntimeError: step fails on purpose"
      When I click the button "Index"
@@ -181,9 +181,9 @@ Feature: Report basics
       | .*         | Feature with background | 2     | 1      | 0      | 1       | passed | .*       |
      When I click the button "Feature with background"
      Then I should see a table that matches the following:
-      | Scenario                            | Total Steps | Status  | Duration |
-      | Scenario which now has a background | 2           | passed  | .*       |
-      | Scenario that is skipped            | 2           | skipped | .*       |
+      | Started at | Scenario                            | Total Steps | Status  | Duration |
+      | .*         | Scenario which now has a background | 2           | passed  | .*       |
+      | .*         | Scenario that is skipped            | 2           | skipped | .*       |
 
   @show-skips
   Scenario: User can run results without skips in the JUnit results
@@ -226,13 +226,13 @@ Feature: Report basics
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/report_only_failures_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
-       | Started at  | Feature                                | Total | Passed | Failed | Skipped | Status | Duration |
-       | .*          | Feature with failing scenario          | 1     | 0      | 1      | 0       | failed | .*       |
-       | .*          | Feature with failing scenario with web | 1     | 0      | 1      | 0       | failed | .*       |
+       | Started at | Feature                                | Total | Passed | Failed | Skipped | Status | Duration |
+       | .*         | Feature with failing scenario          | 1     | 0      | 1      | 0       | failed | .*       |
+       | .*         | Feature with failing scenario with web | 1     | 0      | 1      | 0       | failed | .*       |
      When I click the button "Feature with failing scenario with web"
      Then I should see a table that matches the following:
-       | Scenario                              | Total Steps | Status | Duration |
-       | Just a scenario that opens a web page | 3           | failed | .*       |
+       | Started at | Scenario                              | Total Steps | Status | Duration |
+       | .*         | Just a scenario that opens a web page | 3           | failed | .*       |
      When I click the button "Just a scenario that opens a web page"
       And I wait to click the button "show images"
       And I should see the image with the alt text "And I should see the text "inexistent""

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -128,7 +128,7 @@ Feature: Report basics
      Then I wait to see the text "@all"
      When I click the link "Scenario that is tagged with @second"
      Then I wait to see the text "@second"
-      And I should not see the text "@all"
+      And I should see the text "@all"
       And I should not see the text "@first"
 
   @runtime-timeout
@@ -182,8 +182,8 @@ Feature: Report basics
      When I click the button "Feature with background"
      Then I should see a table that matches the following:
       | Started at | Scenario                            | Total Steps | Status  | Duration |
-      | .*         | Scenario which now has a background | 2           | passed  | .*       |
       | .*         | Scenario that is skipped            | 2           | skipped | .*       |
+      | .*         | Scenario which now has a background | 2           | passed  | .*       |
 
   @show-skips
   Scenario: User can run results without skips in the JUnit results

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -148,14 +148,14 @@ Feature: Report basics
       | Scenario      | Total Steps | Status | Duration |
       | Slow scenario | 1           | .*     |    >*    |
 
-  @report-without-skips
-  Scenario: User can run removed skipped test results from the HTML test report
-    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --report-without-skips --results {CUCU_RESULTS_DIR}/report_without_skips --generate-report --report {CUCU_RESULTS_DIR}/report_without_skips_report" and expect exit code "1"
+  @show-skips
+  Scenario: User can run results without skips in the HTML test report
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --show-skips --results {CUCU_RESULTS_DIR}/report_without_skips --generate-report --report {CUCU_RESULTS_DIR}/report_without_skips_report" and expect exit code "1"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/report_without_skips_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
        | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
-       | Feature with mixed results | 4     | 2      | 2      | 0       | failed | .*       |
+       | Feature with mixed results | 5     | 2      | 2      | 1       | failed | .*       |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
       | Scenario                            | Total Steps | Status  | Duration |
@@ -163,6 +163,7 @@ Feature: Report basics
       | Scenario that has an undefined step | 1           | failed  | .*       |
       | Scenario that passes                | 1           | passed  | .*       |
       | Scenario that also passes           | 1           | passed  | .*       |
+      | Scenario that is skipped            | 1           | skipped | .*       |
       And I click the button "Scenario that fails"
      Then I should see the text "RuntimeError: step fails on purpose"
      When I click the button "Index"
@@ -170,30 +171,33 @@ Feature: Report basics
       And I click the button "Scenario that has an undefined step"
      Then I should see the button "Given I attempt to use an undefined step"
 
-  Scenario: User can run removed skipped test results from the HTML test report on a feature with background
-    Given I run the command "cucu run data/features/feature_with_background.feature --report-without-skips --results {CUCU_RESULTS_DIR}/report_without_skips_background --generate-report --report {CUCU_RESULTS_DIR}/report_without_skips_background_report" and expect exit code "0"
+  @show-skips
+  Scenario: User can run results without skips in the HTML test report on a feature with background
+    Given I run the command "cucu run data/features/feature_with_background.feature --show-skips --results {CUCU_RESULTS_DIR}/report_without_skips_background --generate-report --report {CUCU_RESULTS_DIR}/report_without_skips_background_report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/report_without_skips_background_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
       | Feature                 | Total | Passed | Failed | Skipped | Status | Duration |
-      | Feature with background | 1     | 1      | 0      | 0       | passed | .*       |
+      | Feature with background | 2     | 1      | 0      | 1       | passed | .*       |
      When I click the button "Feature with background"
      Then I should see a table that matches the following:
       | Scenario                            | Total Steps | Status  | Duration |
       | Scenario which now has a background | 2           | passed  | .*       |
+      | Scenario that is skipped            | 2           | skipped | .*       |
 
-  @junit-without-skips
-  Scenario: User can run removed skipped test results from the JUnit results
-    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --junit-without-skips --results {CUCU_RESULTS_DIR}/junit_without_skips" and expect exit code "1"
+  @show-skips
+  Scenario: User can run results without skips in the JUnit results
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --show-skips --results {CUCU_RESULTS_DIR}/junit_without_skips" and expect exit code "1"
       And I read the contents of the file at "{CUCU_RESULTS_DIR}/junit_without_skips/TESTS-Feature_with_mixed_results.xml" and save to the variable "JUNIT"
-     Then I should see "{JUNIT}" contains "skipped=\"0\""
-      And I should see "{JUNIT}" does not contain "<skipped>"
+     Then I should see "{JUNIT}" contains "skipped=\"1\""
+      And I should see "{JUNIT}" contains "<skipped>"
 
-  Scenario: User can run removed skipped test results from the JUnit results when feature has background
-    Given I run the command "cucu run data/features/feature_with_background.feature --junit-without-skips --results {CUCU_RESULTS_DIR}/junit_without_skips_background" and expect exit code "0"
+  @show-skips
+  Scenario: User can run results without skips in the JUnit results when feature has background
+    Given I run the command "cucu run data/features/feature_with_background.feature --show-skips --results {CUCU_RESULTS_DIR}/junit_without_skips_background" and expect exit code "0"
       And I read the contents of the file at "{CUCU_RESULTS_DIR}/junit_without_skips_background/TESTS-Feature_with_background.xml" and save to the variable "JUNIT"
-     Then I should see "{JUNIT}" contains "skipped=\"0\""
-      And I should see "{JUNIT}" does not contain "<skipped>"
+     Then I should see "{JUNIT}" contains "skipped=\"1\""
+      And I should see "{JUNIT}" contains "<skipped>"
 
   Scenario: User can run and generate reports from empty feature files
     Given I create a file at "{CUCU_RESULTS_DIR}/empty_features/environment.py" with the following:

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -53,7 +53,7 @@ Feature: Report basics
       And I should not see the image with the alt text "And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/checkboxes.html""
 
   Scenario: User can run a feature with mixed results and has all results reported correctly
-    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --results {CUCU_RESULTS_DIR}/mixed-results" and expect exit code "1"
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --show-skips --results {CUCU_RESULTS_DIR}/mixed-results" and expect exit code "1"
       And I run the command "cucu report {CUCU_RESULTS_DIR}/mixed-results --show-skips --output {CUCU_RESULTS_DIR}/mixed-results-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/mixed-results-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
@@ -76,7 +76,7 @@ Feature: Report basics
      Then I should see the button "Given I attempt to use an undefined step"
 
   Scenario: User can run feature with background and has all results reported correctly
-    Given I run the command "cucu run data/features/feature_with_background.feature --results {CUCU_RESULTS_DIR}/feature_with_background" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_background.feature --show-skips --results {CUCU_RESULTS_DIR}/feature_with_background" and expect exit code "0"
       And I run the command "cucu report {CUCU_RESULTS_DIR}/feature_with_background --show-skips --output {CUCU_RESULTS_DIR}/feature_with_background-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/feature_with_background-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -58,8 +58,8 @@ Feature: Report basics
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/mixed-results-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
-       | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
-       | Feature with mixed results | 5     | 2      | 2      | 1       | failed | .*       |
+       | Started at | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
+       | .*         | Feature with mixed results | 5     | 2      | 2      | 1       | failed | .*       |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
       | Scenario                            | Total Steps | Status  | Duration |
@@ -81,8 +81,8 @@ Feature: Report basics
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/feature_with_background-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
-       | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
-       | Feature with background    | 2     | 1      | 0      | 1       | passed | .*       |
+       | Started at | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
+       | .*         | Feature with background    | 2     | 1      | 0      | 1       | passed | .*       |
      When I click the button "Feature with background"
      Then I should see a table that matches the following:
       | Scenario                            | Total Steps | Status  | Duration |
@@ -154,8 +154,8 @@ Feature: Report basics
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/report_without_skips_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
-       | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
-       | Feature with mixed results | 5     | 2      | 2      | 1       | failed | .*       |
+      | Started at | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
+      | .*         | Feature with mixed results | 5     | 2      | 2      | 1       | failed | .*       |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
       | Scenario                            | Total Steps | Status  | Duration |
@@ -177,8 +177,8 @@ Feature: Report basics
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/report_without_skips_background_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
-      | Feature                 | Total | Passed | Failed | Skipped | Status | Duration |
-      | Feature with background | 2     | 1      | 0      | 1       | passed | .*       |
+      | Started at | Feature                 | Total | Passed | Failed | Skipped | Status | Duration |
+      | .*         | Feature with background | 2     | 1      | 0      | 1       | passed | .*       |
      When I click the button "Feature with background"
      Then I should see a table that matches the following:
       | Scenario                            | Total Steps | Status  | Duration |
@@ -226,9 +226,9 @@ Feature: Report basics
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/report_only_failures_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
-       | Feature                                | Total | Passed | Failed | Skipped | Status | Duration |
-       | Feature with failing scenario          | 1     | 0      | 1      | 0       | failed | .*       |
-       | Feature with failing scenario with web | 1     | 0      | 1      | 0       | failed | .*       |
+       | Started at  | Feature                                | Total | Passed | Failed | Skipped | Status | Duration |
+       | .*          | Feature with failing scenario          | 1     | 0      | 1      | 0       | failed | .*       |
+       | .*          | Feature with failing scenario with web | 1     | 0      | 1      | 0       | failed | .*       |
      When I click the button "Feature with failing scenario with web"
      Then I should see a table that matches the following:
        | Scenario                              | Total Steps | Status | Duration |

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -52,6 +52,7 @@ Feature: Report basics
       And I should not see the image with the alt text "Given I start a webserver at directory "data/www" and save the port to the variable "PORT""
       And I should not see the image with the alt text "And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/checkboxes.html""
 
+  @show-skips
   Scenario: User can run a feature with mixed results and has all results reported correctly
     Given I run the command "cucu run data/features/feature_with_mixed_results.feature --show-skips --results {CUCU_RESULTS_DIR}/mixed-results" and expect exit code "1"
       And I run the command "cucu report {CUCU_RESULTS_DIR}/mixed-results --show-skips --output {CUCU_RESULTS_DIR}/mixed-results-report" and expect exit code "0"
@@ -75,6 +76,7 @@ Feature: Report basics
       And I click the button "Scenario that has an undefined step"
      Then I should see the button "Given I attempt to use an undefined step"
 
+  @show-skips
   Scenario: User can run feature with background and has all results reported correctly
     Given I run the command "cucu run data/features/feature_with_background.feature --show-skips --results {CUCU_RESULTS_DIR}/feature_with_background" and expect exit code "0"
       And I run the command "cucu report {CUCU_RESULTS_DIR}/feature_with_background --show-skips --output {CUCU_RESULTS_DIR}/feature_with_background-report" and expect exit code "0"
@@ -148,21 +150,19 @@ Feature: Report basics
       | Started at | Scenario      | Total Steps | Status | Duration |
       | .*         | Slow scenario | 1           | .*     |    >*    |
 
-  @show-skips
   Scenario: User can run results without skips in the HTML test report
-    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --show-skips --results {CUCU_RESULTS_DIR}/report_without_skips --generate-report --report {CUCU_RESULTS_DIR}/report_without_skips_report" and expect exit code "1"
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --results {CUCU_RESULTS_DIR}/report_without_skips --generate-report --report {CUCU_RESULTS_DIR}/report_without_skips_report" and expect exit code "1"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/report_without_skips_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
       | Started at | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
-      | .*         | Feature with mixed results | 5     | 2      | 2      | 1       | failed | .*       |
+      | .*         | Feature with mixed results | 4     | 2      | 2      | 0       | failed | .*       |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
       | Started at | Scenario                            | Total Steps | Status  | Duration |
       | .*         | Scenario that also passes           | 1           | passed  | .*       |
       | .*         | Scenario that fails                 | 2           | failed  | .*       |
       | .*         | Scenario that has an undefined step | 1           | failed  | .*       |
-      | .*         | Scenario that is skipped            | 1           | skipped | .*       |
       | .*         | Scenario that passes                | 1           | passed  | .*       |
       And I click the button "Scenario that fails"
      Then I should see the text "RuntimeError: step fails on purpose"
@@ -171,33 +171,29 @@ Feature: Report basics
       And I click the button "Scenario that has an undefined step"
      Then I should see the button "Given I attempt to use an undefined step"
 
-  @show-skips
   Scenario: User can run results without skips in the HTML test report on a feature with background
-    Given I run the command "cucu run data/features/feature_with_background.feature --show-skips --results {CUCU_RESULTS_DIR}/report_without_skips_background --generate-report --report {CUCU_RESULTS_DIR}/report_without_skips_background_report" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_background.feature --results {CUCU_RESULTS_DIR}/report_without_skips_background --generate-report --report {CUCU_RESULTS_DIR}/report_without_skips_background_report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/report_without_skips_background_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
       | Started at | Feature                 | Total | Passed | Failed | Skipped | Status | Duration |
-      | .*         | Feature with background | 2     | 1      | 0      | 1       | passed | .*       |
+      | .*         | Feature with background | 1     | 1      | 0      | 0       | passed | .*       |
      When I click the button "Feature with background"
      Then I should see a table that matches the following:
       | Started at | Scenario                            | Total Steps | Status  | Duration |
-      | .*         | Scenario that is skipped            | 2           | skipped | .*       |
       | .*         | Scenario which now has a background | 2           | passed  | .*       |
 
-  @show-skips
   Scenario: User can run results without skips in the JUnit results
-    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --show-skips --results {CUCU_RESULTS_DIR}/junit_without_skips" and expect exit code "1"
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --results {CUCU_RESULTS_DIR}/junit_without_skips" and expect exit code "1"
       And I read the contents of the file at "{CUCU_RESULTS_DIR}/junit_without_skips/TESTS-Feature_with_mixed_results.xml" and save to the variable "JUNIT"
-     Then I should see "{JUNIT}" contains "skipped=\"1\""
-      And I should see "{JUNIT}" contains "<skipped>"
+     Then I should see "{JUNIT}" contains "skipped=\"0\""
+      And I should see "{JUNIT}" does not contain "<skipped>"
 
-  @show-skips
   Scenario: User can run results without skips in the JUnit results when feature has background
-    Given I run the command "cucu run data/features/feature_with_background.feature --show-skips --results {CUCU_RESULTS_DIR}/junit_without_skips_background" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_background.feature --results {CUCU_RESULTS_DIR}/junit_without_skips_background" and expect exit code "0"
       And I read the contents of the file at "{CUCU_RESULTS_DIR}/junit_without_skips_background/TESTS-Feature_with_background.xml" and save to the variable "JUNIT"
-     Then I should see "{JUNIT}" contains "skipped=\"1\""
-      And I should see "{JUNIT}" contains "<skipped>"
+     Then I should see "{JUNIT}" contains "skipped=\"0\""
+      And I should see "{JUNIT}" does not contain "<skipped>"
 
   Scenario: User can run and generate reports from empty feature files
     Given I create a file at "{CUCU_RESULTS_DIR}/empty_features/environment.py" with the following:

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -63,11 +63,11 @@ Feature: Report basics
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
       | Started at | Scenario                            | Total Steps | Status  | Duration |
+      | .*         | Scenario that also passes           | 1           | passed  | .*       |
       | .*         | Scenario that fails                 | 2           | failed  | .*       |
       | .*         | Scenario that has an undefined step | 1           | failed  | .*       |
-      | .*         | Scenario that passes                | 1           | passed  | .*       |
-      | .*         | Scenario that also passes           | 1           | passed  | .*       |
       | .*         | Scenario that is skipped            | 1           | skipped | .*       |
+      | .*         | Scenario that passes                | 1           | passed  | .*       |
       And I click the button "Scenario that fails"
      Then I should see the text "RuntimeError: step fails on purpose"
      When I click the button "Index"
@@ -86,8 +86,8 @@ Feature: Report basics
      When I click the button "Feature with background"
      Then I should see a table that matches the following:
       | Started at | Scenario                            | Total Steps | Status  | Duration |
-      | .*         | Scenario which now has a background | 2           | passed  | .*       |
       | .*         | Scenario that is skipped            | 2           | skipped | .*       |
+      | .*         | Scenario which now has a background | 2           | passed  | .*       |
 
   @workaround @QE-7075
   @disabled
@@ -159,11 +159,11 @@ Feature: Report basics
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
       | Started at | Scenario                            | Total Steps | Status  | Duration |
+      | .*         | Scenario that also passes           | 1           | passed  | .*       |
       | .*         | Scenario that fails                 | 2           | failed  | .*       |
       | .*         | Scenario that has an undefined step | 1           | failed  | .*       |
-      | .*         | Scenario that passes                | 1           | passed  | .*       |
-      | .*         | Scenario that also passes           | 1           | passed  | .*       |
       | .*         | Scenario that is skipped            | 1           | skipped | .*       |
+      | .*         | Scenario that passes                | 1           | passed  | .*       |
       And I click the button "Scenario that fails"
      Then I should see the text "RuntimeError: step fails on purpose"
      When I click the button "Index"

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -54,7 +54,7 @@ Feature: Report basics
 
   Scenario: User can run a feature with mixed results and has all results reported correctly
     Given I run the command "cucu run data/features/feature_with_mixed_results.feature --results {CUCU_RESULTS_DIR}/mixed-results" and expect exit code "1"
-      And I run the command "cucu report {CUCU_RESULTS_DIR}/mixed-results --output {CUCU_RESULTS_DIR}/mixed-results-report" and expect exit code "0"
+      And I run the command "cucu report {CUCU_RESULTS_DIR}/mixed-results --show-skips --output {CUCU_RESULTS_DIR}/mixed-results-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/mixed-results-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
@@ -77,7 +77,7 @@ Feature: Report basics
 
   Scenario: User can run feature with background and has all results reported correctly
     Given I run the command "cucu run data/features/feature_with_background.feature --results {CUCU_RESULTS_DIR}/feature_with_background" and expect exit code "0"
-      And I run the command "cucu report {CUCU_RESULTS_DIR}/feature_with_background --output {CUCU_RESULTS_DIR}/feature_with_background-report" and expect exit code "0"
+      And I run the command "cucu report {CUCU_RESULTS_DIR}/feature_with_background --show-skips --output {CUCU_RESULTS_DIR}/feature_with_background-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/feature_with_background-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -52,6 +52,28 @@ Feature: Report basics
       And I should not see the image with the alt text "Given I start a webserver at directory "data/www" and save the port to the variable "PORT""
       And I should not see the image with the alt text "And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/checkboxes.html""
 
+  Scenario: User can run a feature with mixed results and has all results reported correctly without skips
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --results {CUCU_RESULTS_DIR}/mixed-results" and expect exit code "1"
+      And I run the command "cucu report {CUCU_RESULTS_DIR}/mixed-results --output {CUCU_RESULTS_DIR}/mixed-results-report" and expect exit code "0"
+      And I start a webserver at directory "{CUCU_RESULTS_DIR}/mixed-results-report/" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
+     Then I should see a table that matches the following:
+       | Started at | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
+       | .*         | Feature with mixed results | 4     | 2      | 2      | 0       | failed | .*       |
+     When I click the button "Feature with mixed results"
+     Then I should see a table that matches the following:
+      | Started at | Scenario                            | Total Steps | Status  | Duration |
+      | .*         | Scenario that also passes           | 1           | passed  | .*       |
+      | .*         | Scenario that fails                 | 2           | failed  | .*       |
+      | .*         | Scenario that has an undefined step | 1           | failed  | .*       |
+      | .*         | Scenario that passes                | 1           | passed  | .*       |
+      And I click the button "Scenario that fails"
+     Then I should see the text "RuntimeError: step fails on purpose"
+     When I click the button "Index"
+      And I click the button "Feature with mixed results"
+      And I click the button "Scenario that has an undefined step"
+     Then I should see the button "Given I attempt to use an undefined step"
+
   @show-skips
   Scenario: User can run a feature with mixed results and has all results reported correctly
     Given I run the command "cucu run data/features/feature_with_mixed_results.feature --show-skips --results {CUCU_RESULTS_DIR}/mixed-results" and expect exit code "1"
@@ -75,6 +97,19 @@ Feature: Report basics
       And I click the button "Feature with mixed results"
       And I click the button "Scenario that has an undefined step"
      Then I should see the button "Given I attempt to use an undefined step"
+
+  Scenario: User can run feature with background and has all results reported correctly without skips
+    Given I run the command "cucu run data/features/feature_with_background.feature --results {CUCU_RESULTS_DIR}/feature_with_background" and expect exit code "0"
+      And I run the command "cucu report {CUCU_RESULTS_DIR}/feature_with_background --output {CUCU_RESULTS_DIR}/feature_with_background-report" and expect exit code "0"
+      And I start a webserver at directory "{CUCU_RESULTS_DIR}/feature_with_background-report/" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
+     Then I should see a table that matches the following:
+       | Started at | Feature                    | Total | Passed | Failed | Skipped | Status | Duration |
+       | .*         | Feature with background    | 1     | 1      | 0      | 0       | passed | .*       |
+     When I click the button "Feature with background"
+     Then I should see a table that matches the following:
+      | Started at | Scenario                            | Total Steps | Status  | Duration |
+      | .*         | Scenario which now has a background | 2           | passed  | .*       |
 
   @show-skips
   Scenario: User can run feature with background and has all results reported correctly

--- a/features/cli/report_search_and_sorting.feature
+++ b/features/cli/report_search_and_sorting.feature
@@ -9,10 +9,10 @@ Feature: Report search and sorting
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/sorting-in-reports-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I wait to see a table that matches the following:
-       | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
-       | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
-       | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
-       | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | Started at | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
+       | .*         | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
+       | .*         | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | .*         | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
 
   Scenario: User can sort by various fields in the HTML test report and share the exact state via the URL
     Given I run the command "cucu run data/features/tagged_features --tags @feature2 --show-skips --results {CUCU_RESULTS_DIR}/sorting-in-reports-results" and expect exit code "0"
@@ -20,23 +20,23 @@ Feature: Report search and sorting
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/sorting-in-reports-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      When I wait to see a table that matches the following:
-       | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
-       | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
-       | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
-       | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | Started at | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
+       | .*         | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
+       | .*         | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | .*         | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
       And I click the table header "Status"
       And I wait to see a table that matches the following:
-       | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
-       | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
-       | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
-       | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
+       | Started at | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
+       | .*         | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | .*         | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | .*         | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
       And I save the current url to the variable "CURRENT_URL"
       And I refresh the browser
      Then I wait to see a table that matches the following:
-       | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
-       | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
-       | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
-       | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
+       | Started at | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
+       | .*         | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | .*         | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | .*         | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
 
   Scenario: User can search by various fields in the HTML test report
     Given I run the command "cucu run data/features/tagged_features --tags @feature2 --show-skips --results {CUCU_RESULTS_DIR}/searching-in-reports-results" and expect exit code "0"
@@ -45,13 +45,13 @@ Feature: Report search and sorting
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      When I write "passed" into the input "Search:"
      Then I wait to see a table that matches the following:
-       | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
-       | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
+       | Started at | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
+       | .*         | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
      When I write "skipped" into the input "Search:"
      Then I wait to see a table that matches the following:
-       | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
-       | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
-       | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | Started at | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
+       | .*         | First tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
+       | .*         | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
 
   Scenario: User can search by various fields in the HTML test report and share the exact state via the URL
     Given I run the command "cucu run data/features/tagged_features --tags @feature2 --results {CUCU_RESULTS_DIR}/searching-in-reports-results" and expect exit code "0"
@@ -60,10 +60,10 @@ Feature: Report search and sorting
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      When I write "passed" into the input "Search:"
      Then I wait to see a table that matches the following:
-       | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
-       | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
+       | Started at | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
+       | .*         | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
      When I save the current url to the variable "CURRENT_URL"
       And I refresh the browser
      Then I wait to see a table that matches the following:
-       | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
-       | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
+       | Started at | Feature               | Total | Passed | Failed | Skipped | Status  | Duration |
+       | .*         | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |

--- a/features/cli/report_search_and_sorting.feature
+++ b/features/cli/report_search_and_sorting.feature
@@ -5,7 +5,7 @@ Feature: Report search and sorting
 
   Scenario: User can sort by various fields in the HTML test report
     Given I run the command "cucu run data/features/tagged_features --tags @feature2 --results {CUCU_RESULTS_DIR}/sorting-in-reports-results" and expect exit code "0"
-      And I run the command "cucu report {CUCU_RESULTS_DIR}/sorting-in-reports-results --output {CUCU_RESULTS_DIR}/sorting-in-reports-report" and expect exit code "0"
+      And I run the command "cucu report {CUCU_RESULTS_DIR}/sorting-in-reports-results --show-skips --output {CUCU_RESULTS_DIR}/sorting-in-reports-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/sorting-in-reports-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I wait to see a table that matches the following:
@@ -16,7 +16,7 @@ Feature: Report search and sorting
 
   Scenario: User can sort by various fields in the HTML test report and share the exact state via the URL
     Given I run the command "cucu run data/features/tagged_features --tags @feature2 --results {CUCU_RESULTS_DIR}/sorting-in-reports-results" and expect exit code "0"
-      And I run the command "cucu report {CUCU_RESULTS_DIR}/sorting-in-reports-results --output {CUCU_RESULTS_DIR}/sorting-in-reports-report" and expect exit code "0"
+      And I run the command "cucu report {CUCU_RESULTS_DIR}/sorting-in-reports-results --show-skips --output {CUCU_RESULTS_DIR}/sorting-in-reports-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/sorting-in-reports-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      When I wait to see a table that matches the following:
@@ -40,7 +40,7 @@ Feature: Report search and sorting
 
   Scenario: User can search by various fields in the HTML test report
     Given I run the command "cucu run data/features/tagged_features --tags @feature2 --results {CUCU_RESULTS_DIR}/searching-in-reports-results" and expect exit code "0"
-      And I run the command "cucu report {CUCU_RESULTS_DIR}/searching-in-reports-results --output {CUCU_RESULTS_DIR}/searching-in-reports-report" and expect exit code "0"
+      And I run the command "cucu report {CUCU_RESULTS_DIR}/searching-in-reports-results --show-skips --output {CUCU_RESULTS_DIR}/searching-in-reports-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/searching-in-reports-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      When I write "passed" into the input "Search:"

--- a/features/cli/report_search_and_sorting.feature
+++ b/features/cli/report_search_and_sorting.feature
@@ -4,7 +4,7 @@ Feature: Report search and sorting
   and use the search and sorting features as expected
 
   Scenario: User can sort by various fields in the HTML test report
-    Given I run the command "cucu run data/features/tagged_features --tags @feature2 --results {CUCU_RESULTS_DIR}/sorting-in-reports-results" and expect exit code "0"
+    Given I run the command "cucu run data/features/tagged_features --tags @feature2 --show-skips --results {CUCU_RESULTS_DIR}/sorting-in-reports-results" and expect exit code "0"
       And I run the command "cucu report {CUCU_RESULTS_DIR}/sorting-in-reports-results --show-skips --output {CUCU_RESULTS_DIR}/sorting-in-reports-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/sorting-in-reports-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
@@ -15,7 +15,7 @@ Feature: Report search and sorting
        | Third tagged feature  | 1     | 0      | 0      | 1       | skipped | .*       |
 
   Scenario: User can sort by various fields in the HTML test report and share the exact state via the URL
-    Given I run the command "cucu run data/features/tagged_features --tags @feature2 --results {CUCU_RESULTS_DIR}/sorting-in-reports-results" and expect exit code "0"
+    Given I run the command "cucu run data/features/tagged_features --tags @feature2 --show-skips --results {CUCU_RESULTS_DIR}/sorting-in-reports-results" and expect exit code "0"
       And I run the command "cucu report {CUCU_RESULTS_DIR}/sorting-in-reports-results --show-skips --output {CUCU_RESULTS_DIR}/sorting-in-reports-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/sorting-in-reports-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
@@ -39,7 +39,7 @@ Feature: Report search and sorting
        | Second tagged feature | 1     | 1      | 0      | 0       | passed  | .*       |
 
   Scenario: User can search by various fields in the HTML test report
-    Given I run the command "cucu run data/features/tagged_features --tags @feature2 --results {CUCU_RESULTS_DIR}/searching-in-reports-results" and expect exit code "0"
+    Given I run the command "cucu run data/features/tagged_features --tags @feature2 --show-skips --results {CUCU_RESULTS_DIR}/searching-in-reports-results" and expect exit code "0"
       And I run the command "cucu report {CUCU_RESULTS_DIR}/searching-in-reports-results --show-skips --output {CUCU_RESULTS_DIR}/searching-in-reports-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/searching-in-reports-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -140,7 +140,7 @@ Feature: Run outputs
       And I should see "{STDERR}" is empty
 
   Scenario: User gets JUnit XML results file as expected
-    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --results {CUCU_RESULTS_DIR}/validate_junit_xml_results" and save stdout to "STDOUT" and expect exit code "1"
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --show-skips --results {CUCU_RESULTS_DIR}/validate_junit_xml_results" and save stdout to "STDOUT" and expect exit code "1"
      Then I should see a file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Feature_with_mixed_results.xml"
       And I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/TESTS-Feature_with_mixed_results.xml" matches the following:
       """

--- a/features/cli/run_with_tags.feature
+++ b/features/cli/run_with_tags.feature
@@ -3,7 +3,7 @@ Feature: Run with tags
   run.
 
   Scenario: User can run a specific feature using a tag
-    Given I run the command "cucu run data/features/feature_with_tagging.feature --tags '@second' --results {CUCU_RESULTS_DIR}/scenario_with_tag_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_tagging.feature --tags '@second' --show-skips --results {CUCU_RESULTS_DIR}/scenario_with_tag_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       @all
@@ -29,7 +29,7 @@ Feature: Run with tags
       And I should see "{STDERR}" is empty
 
   Scenario: User can exclude a specific feature using a tag
-    Given I run the command "cucu run data/features/feature_with_tagging.feature --tags '~@second' --results {CUCU_RESULTS_DIR}/scenario_without_tag_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_tagging.feature --tags '~@second' --show-skips --results {CUCU_RESULTS_DIR}/scenario_without_tag_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       @all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.118.0"
+version = "0.119.0"
 license = "MIT"
 description = ""
 authors = ["Rodney Gomes <rodneygomes@gmail.com>"]

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -118,6 +118,12 @@ def main():
     help="when set skips are shown",
 )
 @click.option(
+    "--show-status",
+    default=False,
+    is_flag=True,
+    help="when set status output is shown (helpful for CI that wants stdout updates)",
+)
+@click.option(
     "--periodic-thread-dumper",
     default=None,
     help="sets the interval in minutes of when to run the periodic thread dumper",
@@ -196,7 +202,6 @@ def run(
     junit,
     junit_with_stacktrace,
     logging_level,
-    show_skips,
     periodic_thread_dumper,
     preserve_results,
     report,
@@ -204,6 +209,8 @@ def run(
     results,
     runtime_timeout,
     secrets,
+    show_skips,
+    show_status,
     tags,
     selenium_remote_url,
     workers,
@@ -256,6 +263,9 @@ def run(
 
     if show_skips:
         os.environ["CUCU_SHOW_SKIPS"] = "true"
+
+    if show_status:
+        os.environ["CUCU_SHOW_STATUS"] = "true"
 
     if junit_with_stacktrace:
         os.environ["CUCU_JUNIT_WITH_STACKTRACE"] = "true"
@@ -427,8 +437,14 @@ def _generate_report(filepath, output, only_failures: False):
     default="INFO",
     help="set logging level to one of debug, warn or info (default)",
 )
+@click.option(
+    "--show-status",
+    default=False,
+    is_flag=True,
+    help="when set status output is shown (helpful for CI that wants stdout updates)",
+)
 @click.option("-o", "--output", default="report")
-def report(filepath, only_failures, logging_level, output):
+def report(filepath, only_failures, logging_level, show_status, output):
     """
     generate a test report from a results directory
     """
@@ -436,6 +452,9 @@ def report(filepath, only_failures, logging_level, output):
 
     os.environ["CUCU_LOGGING_LEVEL"] = logging_level.upper()
     logger.init_logging(logging_level.upper())
+
+    if show_status:
+        os.environ["CUCU_SHOW_STATUS"] = "true"
 
     run_details_filepath = os.path.join(filepath, "run_details.json")
 

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -438,13 +438,21 @@ def _generate_report(filepath, output, only_failures: False):
     help="set logging level to one of debug, warn or info (default)",
 )
 @click.option(
+    "--show-skips",
+    default=False,
+    is_flag=True,
+    help="when set skips are shown",
+)
+@click.option(
     "--show-status",
     default=False,
     is_flag=True,
     help="when set status output is shown (helpful for CI that wants stdout updates)",
 )
 @click.option("-o", "--output", default="report")
-def report(filepath, only_failures, logging_level, show_status, output):
+def report(
+    filepath, only_failures, logging_level, show_skips, show_status, output
+):
     """
     generate a test report from a results directory
     """
@@ -452,6 +460,9 @@ def report(filepath, only_failures, logging_level, show_status, output):
 
     os.environ["CUCU_LOGGING_LEVEL"] = logging_level.upper()
     logger.init_logging(logging_level.upper())
+
+    if show_skips:
+        os.environ["CUCU_SHOW_SKIPS"] = "true"
 
     if show_status:
         os.environ["CUCU_SHOW_STATUS"] = "true"

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -634,10 +634,19 @@ def vars(filepath):
     help="when set to detach the browser will continue to run and "
     "the cucu process will exit",
 )
-def debug(browser, url, detach):
+@click.option(
+    "-l",
+    "--logging-level",
+    default="INFO",
+    help="set logging level to one of debug, warn or info (default)",
+)
+def debug(browser, url, detach, logging_level):
     """
     debug cucu library
     """
+    os.environ["CUCU_LOGGING_LEVEL"] = logging_level.upper()
+    logger.init_logging(logging_level.upper())
+
     fuzzy_js = fuzzy.load_jquery_lib() + fuzzy.load_fuzzy_lib()
     # XXX: need to make this more generic once we make the underlying
     #      browser framework swappable.

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -100,12 +100,6 @@ def main():
     "the same location as --results",
 )
 @click.option(
-    "--junit-without-skips",
-    is_flag=True,
-    default=False,
-    help="when set to true skipped results are removed from the JUnit results",
-)
-@click.option(
     "--junit-with-stacktrace",
     is_flag=True,
     default=False,
@@ -116,6 +110,12 @@ def main():
     "--logging-level",
     default="INFO",
     help="set logging level to one of debug, warn or info (default)",
+)
+@click.option(
+    "--show-skips",
+    default=False,
+    is_flag=True,
+    help="when set skips are shown",
 )
 @click.option(
     "--periodic-thread-dumper",
@@ -138,12 +138,6 @@ def main():
     default=False,
     is_flag=True,
     help="when set the HTML test report will only contain the failed test results",
-)
-@click.option(
-    "--report-without-skips",
-    is_flag=True,
-    default=False,
-    help="when set to true skipped results are removed from the tests report",
 )
 @click.option(
     "-r",
@@ -200,14 +194,13 @@ def run(
     name,
     ipdb_on_failure,
     junit,
-    junit_without_skips,
     junit_with_stacktrace,
     logging_level,
+    show_skips,
     periodic_thread_dumper,
     preserve_results,
     report,
     report_only_failures,
-    report_without_skips,
     results,
     runtime_timeout,
     secrets,
@@ -261,14 +254,11 @@ def run(
     if junit is None:
         junit = results
 
-    if junit_without_skips:
-        os.environ["CUCU_JUNIT_WITHOUT_SKIPS"] = "true"
+    if show_skips:
+        os.environ["CUCU_SHOW_SKIPS"] = "true"
 
     if junit_with_stacktrace:
         os.environ["CUCU_JUNIT_WITH_STACKTRACE"] = "true"
-
-    if report_without_skips:
-        os.environ["CUCU_REPORT_WITHOUT_SKIPS"] = "true"
 
     if report_only_failures:
         os.environ["CUCU_REPORT_ONLY_FAILURES"] = "true"
@@ -307,6 +297,7 @@ def run(
                 junit,
                 results,
                 secrets,
+                show_skips,
                 tags,
                 verbose,
                 skip_init_global_hook_variables=True,
@@ -365,6 +356,7 @@ def run(
                                 junit,
                                 results,
                                 secrets,
+                                show_skips,
                                 tags,
                                 verbose,
                             ],

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -37,6 +37,7 @@ def behave(
     junit,
     results,
     secrets,
+    show_skips,
     tags,
     verbose,
     redirect_output=False,
@@ -130,6 +131,9 @@ def behave(
 
     if fail_fast:
         args.append("--stop")
+
+    if not show_skips:
+        args.append("--no-skipped")
 
     args.append(filepath)
 

--- a/src/cucu/formatter/json.py
+++ b/src/cucu/formatter/json.py
@@ -257,7 +257,9 @@ class CucuJSONFormatter(Formatter):
             x
             for x in feature_data["elements"]
             if x["keyword"] == "Scenario"
-            and (CONFIG["CUCU_SHOW_SKIPS"] or x["status"] != "skipped")
+            and (
+                CONFIG["CUCU_SHOW_SKIPS"] != "true" or x["status"] != "skipped"
+            )
         ]
 
         if len(filtered_scenarios) == 0:

--- a/src/cucu/formatter/json.py
+++ b/src/cucu/formatter/json.py
@@ -258,7 +258,7 @@ class CucuJSONFormatter(Formatter):
             for x in feature_data["elements"]
             if x["keyword"] == "Scenario"
             and (
-                CONFIG["CUCU_SHOW_SKIPS"] != "true" or x["status"] != "skipped"
+                CONFIG["CUCU_SHOW_SKIPS"] == "true" or x["status"] != "skipped"
             )
         ]
 

--- a/src/cucu/formatter/json.py
+++ b/src/cucu/formatter/json.py
@@ -257,10 +257,7 @@ class CucuJSONFormatter(Formatter):
             x
             for x in feature_data["elements"]
             if x["keyword"] == "Scenario"
-            and (
-                not (CONFIG["CUCU_REPORT_WITHOUT_SKIPS"])
-                or x["status"] != "skipped"
-            )
+            and (CONFIG["CUCU_SHOW_SKIPS"] or x["status"] != "skipped")
         ]
 
         if len(filtered_scenarios) == 0:

--- a/src/cucu/formatter/junit.py
+++ b/src/cucu/formatter/junit.py
@@ -200,7 +200,7 @@ class CucuJUnitFormatter(Formatter):
 
         scenarios = results["scenarios"]
 
-        if CONFIG["CUCU_JUNIT_WITHOUT_SKIPS"]:
+        if CONFIG["CUCU_SHOW_SKIPS"] != "true":
             filtered_scenarios = {}
 
             for name, scenario in scenarios.items():

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -48,6 +48,8 @@ def generate(results, basepath, only_failures=False):
     generate an HTML report for the results provided.
     """
 
+    show_status = CONFIG["CUCU_SHOW_STATUS"] == "true"
+
     features = []
 
     run_json_filepaths = list(glob.iglob(os.path.join(results, "*run.json")))
@@ -59,8 +61,11 @@ def generate(results, basepath, only_failures=False):
         with open(run_json_filepath, "rb") as index_input:
             try:
                 features += json.loads(index_input.read())
-                print("r", end="", flush=True)
+                if show_status:
+                    print("r", end="", flush=True)
             except Exception as exception:
+                if show_status:
+                    print("")  # add a newline before logger
                 logger.warn(
                     f"unable to read file {run_json_filepath}, got error: {exception}"
                 )
@@ -78,7 +83,8 @@ def generate(results, basepath, only_failures=False):
     #
     reported_features = []
     for feature in features:
-        print("F", end="", flush=True)
+        if show_status:
+            print("F", end="", flush=True)
         scenarios = []
 
         if feature["status"] != "untested" and "elements" in feature:
@@ -105,7 +111,8 @@ def generate(results, basepath, only_failures=False):
             )
 
         for scenario in scenarios:
-            print("S", end="", flush=True)
+            if show_status:
+                print("S", end="", flush=True)
             process_tags(scenario)
 
             scenario_duration = 0
@@ -127,7 +134,8 @@ def generate(results, basepath, only_failures=False):
 
             step_index = 0
             for step in scenario["steps"]:
-                print("s", end="", flush=True)
+                if show_status:
+                    print("s", end="", flush=True)
                 total_steps += 1
                 image_filename = (
                     f"{step_index} - {step['name'].replace('/', '_')}.png"
@@ -150,7 +158,8 @@ def generate(results, basepath, only_failures=False):
                 log_files = []
 
                 for log_file in glob.iglob(os.path.join(logs_dir, "*.*")):
-                    print("l", end="", flush=True)
+                    if show_status:
+                        print("l", end="", flush=True)
 
                     log_filepath = log_file.removeprefix(
                         f"{scenario_filepath}/"
@@ -171,7 +180,8 @@ def generate(results, basepath, only_failures=False):
                 only_console_logs = lambda log: ".console." in log["name"]
 
                 for log_file in filter(only_console_logs, log_files):
-                    print("c", end="", flush=True)
+                    if show_status:
+                        print("c", end="", flush=True)
 
                     converter = Ansi2HTMLConverter(dark_bg=False)
                     log_file_filepath = os.path.join(
@@ -204,6 +214,8 @@ def generate(results, basepath, only_failures=False):
 
     package_loader = jinja2.PackageLoader("cucu.reporter", "templates")
     templates = jinja2.Environment(loader=package_loader)
+    if show_status:
+        print("")  # add a newline to end status
 
     def urlencode(string):
         """

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -151,6 +151,28 @@ def generate(results, basepath, only_failures=False):
                 if "text" in step and not isinstance(step["text"], list):
                     step["text"] = [step["text"]]
 
+                if "text" in step:
+                    text_indent = "       "
+                    step["text"] = "\n".join(
+                        [text_indent + '"""']
+                        + [f"{text_indent}{x}" for x in step["text"]]
+                        + [text_indent + '"""']
+                    )
+
+                if "table" in step:
+                    text_indent = "       "
+                    step["table"] = "\n".join(
+                        [
+                            text_indent
+                            + "| "
+                            + " | ".join(step["table"]["headings"])
+                            + " |"
+                        ]
+                        + [
+                            text_indent + "| " + " | ".join(row) + " |"
+                            for row in step["table"]["rows"]
+                        ]
+                    )
                 step_index += 1
             logs_dir = os.path.join(scenario_filepath, "logs")
 

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -258,6 +258,19 @@ def generate(results, basepath, only_failures=False):
     with open(index_output_filepath, "wb") as output:
         output.write(rendered_index_html.encode("utf8"))
 
+    flat_template = templates.get_template("flat.html")
+    rendered_flat_html = flat_template.render(
+        features=reported_features,
+        grand_totals=grand_totals,
+        title="Flat HTML Test Report",
+        basepath=basepath,
+        dir_depth="",
+    )
+
+    flat_output_filepath = os.path.join(basepath, "flat.html")
+    with open(flat_output_filepath, "wb") as output:
+        output.write(rendered_flat_html.encode("utf8"))
+
     feature_template = templates.get_template("feature.html")
 
     for feature in reported_features:

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -156,6 +156,7 @@ def generate(results, basepath, only_failures=False):
                 if "text" in step and not isinstance(step["text"], list):
                     step["text"] = [step["text"]]
 
+                # prepare by joining into one big chunk here since we can't do it in the Jinja template
                 if "text" in step:
                     text_indent = "       "
                     step["text"] = "\n".join(
@@ -164,6 +165,7 @@ def generate(results, basepath, only_failures=False):
                         + [text_indent + '"""']
                     )
 
+                # prepare by joining into one big chunk here since we can't do it in the Jinja template
                 if "table" in step:
                     text_indent = "       "
                     step["table"] = "\n".join(

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -203,10 +203,12 @@ def generate(results, basepath, only_failures=False):
                         )
 
             scenario["total_steps"] = total_steps
+            scenario["started_at"] = scenario["steps"][0]["result"]["timestamp"]
             scenario["duration"] = scenario_duration
             feature_duration += scenario_duration
 
         feature["total_steps"] = sum([x["total_steps"] for x in scenarios])
+        feature["started_at"] = min([x["started_at"] for x in scenarios])
         feature["duration"] = sum([x["duration"] for x in scenarios])
 
         feature["total_scenarios"] = total_scenarios

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -202,15 +202,28 @@ def generate(results, basepath, only_failures=False):
                             converter.convert(log_file_input.read())
                         )
 
-            scenario["duration"] = scenario_duration
             scenario["total_steps"] = total_steps
+            scenario["duration"] = scenario_duration
             feature_duration += scenario_duration
+
+        feature["total_steps"] = sum([x["total_steps"] for x in scenarios])
+        feature["duration"] = sum([x["duration"] for x in scenarios])
 
         feature["total_scenarios"] = total_scenarios
         feature["total_scenarios_passed"] = total_scenarios_passed
         feature["total_scenarios_failed"] = total_scenarios_failed
         feature["total_scenarios_skipped"] = total_scenarios_skipped
-        feature["duration"] = feature_duration
+
+    keys = [
+        "total_scenarios",
+        "total_scenarios_passed",
+        "total_scenarios_failed",
+        "total_scenarios_skipped",
+        "duration",
+    ]
+    grand_totals = {}
+    for k in keys:
+        grand_totals[k] = sum([x[k] for x in reported_features])
 
     package_loader = jinja2.PackageLoader("cucu.reporter", "templates")
     templates = jinja2.Environment(loader=package_loader)
@@ -233,6 +246,7 @@ def generate(results, basepath, only_failures=False):
     index_template = templates.get_template("index.html")
     rendered_index_html = index_template.render(
         features=reported_features,
+        grand_totals=grand_totals,
         title="Cucu HTML Test Report",
         basepath=basepath,
         dir_depth="",

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -203,7 +203,12 @@ def generate(results, basepath, only_failures=False):
                         )
 
             scenario["total_steps"] = total_steps
-            scenario["started_at"] = scenario["steps"][0]["result"]["timestamp"]
+            if len(scenario["steps"]) > 0 and "result" in scenario["steps"][0]:
+                scenario["started_at"] = scenario["steps"][0]["result"][
+                    "timestamp"
+                ]
+            else:
+                scenario["started_at"] = ""
             scenario["duration"] = scenario_duration
             feature_duration += scenario_duration
 

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -148,6 +148,11 @@ def generate(results, basepath, only_failures=False):
                 if "result" in step:
                     scenario_duration += step["result"]["duration"]
 
+                    if "error_message" in step["result"] and step["result"][
+                        "error_message"
+                    ] == [None]:
+                        step["result"]["error_message"] = [""]
+
                 if "text" in step and not isinstance(step["text"], list):
                     step["text"] = [step["text"]]
 
@@ -173,6 +178,7 @@ def generate(results, basepath, only_failures=False):
                             for row in step["table"]["rows"]
                         ]
                     )
+
                 step_index += 1
             logs_dir = os.path.join(scenario_filepath, "logs")
 
@@ -235,7 +241,7 @@ def generate(results, basepath, only_failures=False):
             feature_duration += scenario_duration
 
         feature["total_steps"] = sum([x["total_steps"] for x in scenarios])
-        feature["started_at"] = min([x["started_at"] for x in scenarios])
+        feature["started_at"] = scenarios[0]["started_at"]
         feature["duration"] = sum([x["duration"] for x in scenarios])
 
         feature["total_scenarios"] = total_scenarios

--- a/src/cucu/reporter/templates/feature.html
+++ b/src/cucu/reporter/templates/feature.html
@@ -2,7 +2,7 @@
 {% block content %}
     <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
         <div class="container-fluid">
-            <a class="navbar-brand" href="#">HTML Test Report</a>
+            <a class="navbar-brand" href="#">Feature HTML Test Report</a>
 
             <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
               <ul class="navbar-nav mr-auto mt-2 mt-lg-0">

--- a/src/cucu/reporter/templates/feature.html
+++ b/src/cucu/reporter/templates/feature.html
@@ -52,6 +52,6 @@
     </table>
 
     <script>
-    setupReportTables([[2, 'asc']], [{type: 'timestamp', searchable: false}, {type: 'string'}, {type: 'num', searchable: false}, {type: 'html'} , {type: 'timestamp', searchable: false} ])
+    setupReportTables([[1, 'asc']], [{type: 'timestamp', searchable: false}, {type: 'string'}, {type: 'num', searchable: false}, {type: 'html'} , {type: 'timestamp', searchable: false} ])
     </script>
 {% endblock %}

--- a/src/cucu/reporter/templates/feature.html
+++ b/src/cucu/reporter/templates/feature.html
@@ -19,10 +19,21 @@
     </table>
     <table class="table table-hover datatable">
         <thead>
-            <tr>
+            <tr class="align-text-top">
+                <th class="text-center">Started at<br/>{{ feature['started_at'] }}</th>
                 <th>Scenario</th>
                 <th class="text-center">Total Steps<br/>{{ feature['total_steps'] }}</th>
-                <th class="text-center">Status<br/>&nbsp;</th>
+                <th class="text-center">Status<br/>
+                    {% if feature['status'] == 'passed' %}
+                        <span style="display: inline; color: green">{{ feature['status'] }}</span>
+                    {% elif feature['status'] == 'failed' %}
+                        <span style="display: inline; color: red">{{ feature['status'] }}</span>
+                    {% elif feature['status'] == 'skipped' %}
+                        <span style="display: inline; color: blue">{{ feature['status'] }}</span>
+                    {% elif feature['status'] == 'untested' %}
+                        <span style="display: inline; color: gray">{{ feature['status'] }}</span>
+                    {% endif %}
+                </th>
                 <th class="text-center">Duration<br/>{{ '{:.3f}'.format(feature['duration']) }}s</th>
             </tr>
         </thead>
@@ -30,6 +41,7 @@
             <!--- ignore Backgrounds for the time being -->
             {% if scenario['keyword'] != 'Background' %}
             <tr>
+                <td class="text-center">{{ scenario['started_at'] }}</td>
                 <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><pre style="display: inline; color: grey">{{ escape(scenario['name']) }}</pre></a></td>
                 <td class="text-center">{{ scenario['total_steps'] }}</td>
                 {% if scenario['status'] == 'passed' %}
@@ -46,6 +58,6 @@
     </table>
 
     <script>
-    setupReportTables([[2, 'asc']], [{type: 'string'}, {type: 'num'}, {type: 'html'} , {type: 'timestamp'} ])
+    setupReportTables([[2, 'asc']], [{type: 'timestamp', searchable: false}, {type: 'string'}, {type: 'num', searchable: false}, {type: 'html'} , {type: 'timestamp', searchable: false} ])
     </script>
 {% endblock %}

--- a/src/cucu/reporter/templates/feature.html
+++ b/src/cucu/reporter/templates/feature.html
@@ -21,9 +21,9 @@
         <thead>
             <tr>
                 <th>Scenario</th>
-                <th class="text-center">Total Steps</th>
-                <th class="text-center">Status</th>
-                <th class="text-center">Duration</th>
+                <th class="text-center">Total Steps<br/>{{ feature['total_steps'] }}</th>
+                <th class="text-center">Status<br/>&nbsp;</th>
+                <th class="text-center">Duration<br/>{{ '{:.3f}'.format(feature['duration']) }}s</th>
             </tr>
         </thead>
         {% for scenario in scenarios %}

--- a/src/cucu/reporter/templates/feature.html
+++ b/src/cucu/reporter/templates/feature.html
@@ -14,8 +14,8 @@
         </div>
     </nav>
     <table class="table table-hover">
-        <tr class="remove-table-hover"><pre style="display: inline; color: mediumturquoise">{{ feature['tags'] }}</pre><br/></tr>
-        <tr class="remove-table-hover"><pre style="display: inline; color: maroon">Feature: </pre><pre style="display: inline; color: grey">{{ escape(feature['name']) }}</pre></tr>
+        <tr class="remove-table-hover"><span style="display: inline; color: mediumturquoise">{{ feature['tags'] }}</span><br/></tr>
+        <tr class="remove-table-hover"><span style="display: inline; color: maroon">Feature: </span><span style="display: inline; color: grey">{{ escape(feature['name']) }}</span></tr>
     </table>
     <table class="table table-hover datatable">
         <thead>
@@ -42,15 +42,9 @@
             {% if scenario['keyword'] != 'Background' %}
             <tr>
                 <td class="text-center">{{ scenario['started_at'] }}</td>
-                <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><pre style="display: inline; color: grey">{{ escape(scenario['name']) }}</pre></a></td>
+                <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><span style="display: inline; color: grey">{{ escape(scenario['name']) }}</span></a></td>
                 <td class="text-center">{{ scenario['total_steps'] }}</td>
-                {% if scenario['status'] == 'passed' %}
-                    <td class="text-center"><pre style="display: inline; color: green">{{ scenario['status'] }}</pre></td>
-                {% elif scenario['status'] == 'failed' %}
-                    <td class="text-center"><pre style="display: inline; color: red">{{ scenario['status'] }}</pre></td>
-                {% elif scenario['status'] == 'skipped' %}
-                    <td class="text-center"><pre style="display: inline; color: blue">{{ scenario['status'] }}</pre></td>
-                {% endif %}
+                <td class="text-center"><span class="status-{{ scenario['status'] }}">{{ scenario['status'] }}</span></td>
                 <td class="text-center">{{ '{:.3f}'.format(scenario['duration']) }}s</td>
             </tr>
             {%  endif %}

--- a/src/cucu/reporter/templates/feature.html
+++ b/src/cucu/reporter/templates/feature.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block content %}
+{% block nav %}
     <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
         <div class="container-fluid">
             <a class="navbar-brand" href="#">Feature HTML Test Report</a>
@@ -13,6 +13,8 @@
             </div>
         </div>
     </nav>
+{% endblock %}
+{% block content %}
     <table class="table table-hover">
         <tr class="remove-table-hover"><span style="display: inline; color: mediumturquoise">{{ feature['tags'] }}</span><br/></tr>
         <tr class="remove-table-hover"><span style="display: inline; color: maroon">Feature: </span><span style="display: inline; color: grey">{{ escape(feature['name']) }}</span></tr>

--- a/src/cucu/reporter/templates/flat.html
+++ b/src/cucu/reporter/templates/flat.html
@@ -29,7 +29,7 @@
                 {% if scenario['keyword'] != 'Background' %}
                 <tr>
                     <td class="text-center">{{ scenario['started_at'] }}</td>
-                    <td class="text-center">{{ feature['name'] }}</td>
+                    <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><pre style="display: inline; color: grey">{{ escape(feature['name']) }}</pre></a></td>
                     <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><pre style="display: inline; color: grey">{{ escape(scenario['name']) }}</pre></a></td>
                     <td class="text-center">{{ scenario['total_steps'] }}</td>
                     {% if scenario['status'] == 'passed' %}

--- a/src/cucu/reporter/templates/flat.html
+++ b/src/cucu/reporter/templates/flat.html
@@ -29,16 +29,10 @@
                 {% if scenario['keyword'] != 'Background' %}
                 <tr>
                     <td class="text-center">{{ scenario['started_at'] }}</td>
-                    <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><pre style="display: inline; color: grey">{{ escape(feature['name']) }}</pre></a></td>
-                    <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><pre style="display: inline; color: grey">{{ escape(scenario['name']) }}</pre></a></td>
+                    <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><span style="display: inline; color: grey">{{ escape(feature['name']) }}</span></a></td>
+                    <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><span style="display: inline; color: grey">{{ escape(scenario['name']) }}</span></a></td>
                     <td class="text-center">{{ scenario['total_steps'] }}</td>
-                    {% if scenario['status'] == 'passed' %}
-                        <td class="text-center"><pre style="display: inline; color: green">{{ scenario['status'] }}</pre></td>
-                    {% elif scenario['status'] == 'failed' %}
-                        <td class="text-center"><pre style="display: inline; color: red">{{ scenario['status'] }}</pre></td>
-                    {% elif scenario['status'] == 'skipped' %}
-                        <td class="text-center"><pre style="display: inline; color: blue">{{ scenario['status'] }}</pre></td>
-                    {% endif %}
+                    <td class="text-center"><span class="status-{{ scenario['status'] }}">{{ scenario['status'] }}</span></td>
                     <td class="text-center">{{ '{:.3f}'.format(scenario['duration']) }}s</td>
                 </tr>
                 {%  endif %}

--- a/src/cucu/reporter/templates/flat.html
+++ b/src/cucu/reporter/templates/flat.html
@@ -1,0 +1,52 @@
+{% extends "layout.html" %}
+{% block content %}
+    <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
+        <div class="container-fluid">
+          <a class="navbar-brand" href="#">Flat HTML Test Report</a>
+            <div class="collapse navbar-collapse">
+              <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
+                <li class="nav-item active">
+                  <a class="nav-link" href="index.html" title="go to all report">Index</a>
+                </li>
+              </ul>
+            </div>
+        </div>
+    </nav>
+    <table class="table table-hover datatable">
+        <thead>
+            <tr class="align-text-top">
+                <th class="text-center">Started at</th>
+                <th>Feature</th>
+                <th>Scenario</th>
+                <th class="text-center">Total Steps</th>
+                <th class="text-center">Status</th>
+                <th class="text-center">Duration</th>
+            </tr>
+        </thead>
+        {% for feature in features %}
+            {% for scenario in feature["elements"] %}
+                <!--- ignore Backgrounds for the time being -->
+                {% if scenario['keyword'] != 'Background' %}
+                <tr>
+                    <td class="text-center">{{ scenario['started_at'] }}</td>
+                    <td class="text-center">{{ feature['name'] }}</td>
+                    <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><pre style="display: inline; color: grey">{{ escape(scenario['name']) }}</pre></a></td>
+                    <td class="text-center">{{ scenario['total_steps'] }}</td>
+                    {% if scenario['status'] == 'passed' %}
+                        <td class="text-center"><pre style="display: inline; color: green">{{ scenario['status'] }}</pre></td>
+                    {% elif scenario['status'] == 'failed' %}
+                        <td class="text-center"><pre style="display: inline; color: red">{{ scenario['status'] }}</pre></td>
+                    {% elif scenario['status'] == 'skipped' %}
+                        <td class="text-center"><pre style="display: inline; color: blue">{{ scenario['status'] }}</pre></td>
+                    {% endif %}
+                    <td class="text-center">{{ '{:.3f}'.format(scenario['duration']) }}s</td>
+                </tr>
+                {%  endif %}
+            {% endfor %}
+        {% endfor %}
+    </table>
+
+    <script>
+    setupReportTables([[2, 'asc']], [{type: 'timestamp', searchable: false}, {type: 'string'}, {type: 'string'}, {type: 'num', searchable: false}, {type: 'html'} , {type: 'timestamp', searchable: false} ])
+    </script>
+{% endblock %}

--- a/src/cucu/reporter/templates/flat.html
+++ b/src/cucu/reporter/templates/flat.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block content %}
+{% block nav %}
     <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
         <div class="container-fluid">
           <a class="navbar-brand" href="#">Flat HTML Test Report</a>
@@ -12,6 +12,8 @@
             </div>
         </div>
     </nav>
+{% endblock %}
+{% block content %}
     <table class="table table-hover datatable">
         <thead>
             <tr class="align-text-top">

--- a/src/cucu/reporter/templates/flat.html
+++ b/src/cucu/reporter/templates/flat.html
@@ -31,8 +31,8 @@
                 {% if scenario['keyword'] != 'Background' %}
                 <tr>
                     <td class="text-center">{{ scenario['started_at'] }}</td>
-                    <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><span style="display: inline; color: grey">{{ escape(feature['name']) }}</span></a></td>
-                    <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><span style="display: inline; color: grey">{{ escape(scenario['name']) }}</span></a></td>
+                    <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><span>{{ escape(feature['name']) }}</span></a></td>
+                    <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><span>{{ escape(scenario['name']) }}</span></a></td>
                     <td class="text-center">{{ scenario['total_steps'] }}</td>
                     <td class="text-center"><span class="status-{{ scenario['status'] }}">{{ scenario['status'] }}</span></td>
                     <td class="text-center">{{ '{:.3f}'.format(scenario['duration']) }}s</td>

--- a/src/cucu/reporter/templates/index.html
+++ b/src/cucu/reporter/templates/index.html
@@ -2,7 +2,7 @@
 {% block content %}
     <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
         <div class="container-fluid">
-          <a class="navbar-brand" href="#">HTML Test Report</a>
+          <a class="navbar-brand" href="#">Index HTML Test Report</a>
             <div class="collapse navbar-collapse">
               <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
                 <li class="nav-item active">

--- a/src/cucu/reporter/templates/index.html
+++ b/src/cucu/reporter/templates/index.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block content %}
+{% block nav %}
     <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
         <div class="container-fluid">
           <a class="navbar-brand" href="#">Index HTML Test Report</a>
@@ -12,6 +12,8 @@
             </div>
         </div>
     </nav>
+{% endblock %}
+{% block content %}
     <table class="table table-hover datatable">
         <thead>
             <tr class="align-text-top">

--- a/src/cucu/reporter/templates/index.html
+++ b/src/cucu/reporter/templates/index.html
@@ -7,7 +7,8 @@
     </nav>
     <table class="table table-hover datatable">
         <thead>
-            <tr>
+            <tr class="align-text-top">
+                <th class="text-center">Started at</th>
                 <th>Feature</th>
                 <th class="text-center">Total<br/>{{ grand_totals['total_scenarios'] }}</th>
                 <th class="text-center">Passed<br/>{{ grand_totals['total_scenarios_passed'] }}</th>
@@ -19,6 +20,7 @@
         </thead>
         {% for feature in features %}
         <tr>
+            <td class="text-center">{{ feature['started_at'] }}</td>
             <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><pre style="display: inline; color: grey">{{ escape(feature['name']) }}</pre></a></td>
             <td class="text-center">{{ feature['total_scenarios'] }}</td>
             <td class="text-center">{{ feature['total_scenarios_passed'] }}</td>
@@ -39,6 +41,6 @@
     </table>
 
     <script>
-    setupReportTables([[5, 'asc']], [{type: 'string'}, {type: 'num'}, {type: 'num'}, {type: 'num'}, {type: 'num'}, {type: 'html'} , {type: 'timestamp'} ])
+    setupReportTables([[6, 'asc']], [{type: 'timestamp', searchable: false}, {type: 'string'}, {type: 'num', searchable: false}, {type: 'num', searchable: false}, {type: 'num', searchable: false}, {type: 'num', searchable: false}, {type: 'html'} , {type: 'timestamp', searchable: false} ])
     </script>
 {% endblock %}

--- a/src/cucu/reporter/templates/index.html
+++ b/src/cucu/reporter/templates/index.html
@@ -9,12 +9,12 @@
         <thead>
             <tr>
                 <th>Feature</th>
-                <th class="text-center">Total</th>
-                <th class="text-center">Passed</th>
-                <th class="text-center">Failed</th>
-                <th class="text-center">Skipped</th>
-                <th class="text-center">Status</th>
-                <th class="text-center">Duration</th>
+                <th class="text-center">Total<br/>{{ grand_totals['total_scenarios'] }}</th>
+                <th class="text-center">Passed<br/>{{ grand_totals['total_scenarios_passed'] }}</th>
+                <th class="text-center">Failed<br/>{{ grand_totals['total_scenarios_failed'] }}</th>
+                <th class="text-center">Skipped<br/>{{ grand_totals['total_scenarios_skipped'] }}</th>
+                <th class="text-center">Status<br/>&nbsp;</th>
+                <th class="text-center">Duration<br/>{{ '{:.3f}'.format(grand_totals['duration']) }}s</th>
             </tr>
         </thead>
         {% for feature in features %}

--- a/src/cucu/reporter/templates/index.html
+++ b/src/cucu/reporter/templates/index.html
@@ -3,6 +3,13 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
         <div class="container-fluid">
           <a class="navbar-brand" href="#">HTML Test Report</a>
+            <div class="collapse navbar-collapse">
+              <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
+                <li class="nav-item active">
+                  <a class="nav-link" href="flat.html" title="go to all report">Flat</a>
+                </li>
+              </ul>
+            </div>
         </div>
     </nav>
     <table class="table table-hover datatable">

--- a/src/cucu/reporter/templates/index.html
+++ b/src/cucu/reporter/templates/index.html
@@ -28,20 +28,12 @@
         {% for feature in features %}
         <tr>
             <td class="text-center">{{ feature['started_at'] }}</td>
-            <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><pre style="display: inline; color: grey">{{ escape(feature['name']) }}</pre></a></td>
+            <td><a href="{{ urlencode(escape(feature['name'])) }}.html">{{ escape(feature['name']) }}</a></td>
             <td class="text-center">{{ feature['total_scenarios'] }}</td>
             <td class="text-center">{{ feature['total_scenarios_passed'] }}</td>
             <td class="text-center">{{ feature['total_scenarios_failed'] }}</td>
             <td class="text-center">{{ feature['total_scenarios_skipped'] }}</td>
-            {% if feature['status'] == 'passed' %}
-                <td class="text-center"><pre style="display: inline; color: green">{{ feature['status'] }}</pre></td>
-            {% elif feature['status'] == 'failed' %}
-                <td class="text-center"><pre style="display: inline; color: red">{{ feature['status'] }}</pre></td>
-            {% elif feature['status'] == 'skipped' %}
-                <td class="text-center"><pre style="display: inline; color: blue">{{ feature['status'] }}</pre></td>
-            {% elif feature['status'] == 'untested' %}
-                <td class="text-center"><pre style="display: inline; color: gray">{{ feature['status'] }}</pre></td>
-            {% endif %}
+            <td class="text-center"><span class="status-{{ feature['status'] }}">{{ feature['status'] }}</span></td>
             <td class="text-center">{{ '{:.3f}'.format(feature['duration']) }}s</td>
         </tr>
         {% endfor %}

--- a/src/cucu/reporter/templates/layout.html
+++ b/src/cucu/reporter/templates/layout.html
@@ -98,8 +98,11 @@
   <body>
     <div class="row justify-content-md-center">
         <div class="col-10">
-            {% block content %}{% endblock %}
+            {% block nav %}{% endblock %}
         </div>
+    </div>
+    <div class="container">
+        {% block content %}{% endblock %}
     </div>
   </body>
 </html>

--- a/src/cucu/reporter/templates/layout.html
+++ b/src/cucu/reporter/templates/layout.html
@@ -29,9 +29,6 @@
             text-decoration: underline;
         }
     }
-    tr.d-flex, tr.d-flex td {
-        min-width: 0;
-    }
 
     .status-passed {
         display: inline;

--- a/src/cucu/reporter/templates/layout.html
+++ b/src/cucu/reporter/templates/layout.html
@@ -29,6 +29,9 @@
             text-decoration: underline;
         }
     }
+    tr.d-flex, tr.d-flex td {
+        min-width: 0;
+    }
 
     .status-passed {
         display: inline;

--- a/src/cucu/reporter/templates/layout.html
+++ b/src/cucu/reporter/templates/layout.html
@@ -17,6 +17,35 @@
     .remove-table-hover tr:hover{
        background-color: unset !important;
     }
+    @link-color:       @brand-primary;
+    @link-hover-color: darken(@link-color, 15%);
+
+    a {
+        color: @link-color;
+        text-decoration: none;
+
+        &:hover {
+            color: @link-hover-color;
+            text-decoration: underline;
+        }
+    }
+
+    .status-passed {
+        display: inline;
+        color: green;
+    }
+    .status-failed {
+        display: inline;
+        color: red;
+    }
+    .status-skipped {
+        display: inline;
+        color: blue;
+    }
+    .status-untested {
+        display: inline;
+        color: gray;
+    }
     </style>
     <script>
         function setupReportTables(defaultOrder, columns) {

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -55,11 +55,11 @@
     }
     </style>
     <table class="table table-borderless">
-        <tr class="remove-table-hover"><pre style="display: inline; color: mediumturquoise">{{ feature['tags'] }} {{ scenario['tags'] }}</pre><br/></tr>
+        <tr class="remove-table-hover"><span style="display: inline; color: mediumturquoise">{{ feature['tags'] }} {{ scenario['tags'] }}</span><br/></tr>
         <tr class="d-flex">
             <td class="col-8 text-truncate">
-                <pre style="display: inline; color: maroon;">Feature: </pre> {{ escape(feature['name']) }}<br/>
-                <pre style="display: inline; color: maroon;">Scenario:</pre> {{ escape(scenario['name']) }}
+                <span style="display: inline; color: maroon;">Feature: </span> {{ escape(feature['name']) }}<br/>
+                <span style="display: inline; color: maroon;">Scenario:</span> {{ escape(scenario['name']) }}
             </td>
             <td class="col-4 text-truncate" style="color: gray;"></td>
         </tr>
@@ -71,65 +71,36 @@
                 {% set step_prefix = "" %}
             {% endif %}
             {% if step['result'] is defined %}
+                {% set step_status = step['result']['status'] %}
                 {% if step['result']['status'] == 'failed' or step['result']['status'] == 'passed' %}
                     {% set step_timing = "# started at {} took {:.3f}s".format(step["result"]["timestamp"], step["result"]["duration"]) %}
                 {% endif %}
             {% else %}
+                {% set step_status = 'untested' %}
                 {% set step_timing = "" %}
             {% endif %}
             {% set step_keyword = step_prefix + step['keyword'].rjust(6, ' ') %}
             <tr class="d-flex">
                 <td class="anchor-toggle text-truncate col-8" data-toggle="collapse" href="#collapsable-row-{{ loop.index }}" role="button" aria-expanded="false" aria-controls="collapsable-row-{{ loop.index }}">
                     <a class="anchor" id="step_{{ loop.index}}" href="#step_{{ loop.index }}">🔗</a>
-                {% if step['result'] is not defined %}
-                    <pre style="display: inline; color: blue">{{ step_keyword }}</pre><pre style="color: blue; display: inline"> {{ escape(step['name']) }}</pre>
-                {% elif step['result']['status'] == 'passed' %}
-                    <pre style="display: inline; color: green">{{ step_keyword }}</pre><pre style="display: inline; text-overflow: ellipsis; overflow: hidden;"> {{ escape(step['name']) }}</pre>
-                {% elif step['result']['status'] == 'failed' %}
-                    <pre style="display: inline; color: red">{{ step_keyword }}</pre><pre style="color: red; display: inline"> {{ escape(step['name']) }}</pre>
-                {% elif step['result']['status'] == 'skipped' %}
-                    <pre style="display: inline; color: blue">{{ step_keyword }}</pre><pre style="color: blue; display: inline"> {{ escape(step['name']) }}</pre>
-                {% elif step['result']['status'] == 'undefined' %}
-                    <pre style="display: inline; color: orange">{{ step_keyword }}</pre><pre style="color: orange; display: inline"> {{ escape(step['name']) }}</pre>
-                {% endif %}
-                </td>
-                <td><pre style="display: inline; color: gray;">{{ step_timing }}</pre></td>
-            </tr>
+                    <pre class="status-{{ step_status }}">{{ step_keyword }}</pre><span class="status-{{ step['result'] }}"> {{ escape(step['name']) }}</span>
             {% if step['text'] %}
-            <tr class="d-flex">
-                <td class="col-8" colspan="2">
-                    <pre style="color: black; margin: 0">       """</pre>
-                    {% for line in step['text'] %}
-                        <pre style="color: black; margin: 0">       {{ line }}</pre>
-                    {% endfor %}
-                    <pre style="color: black; margin: 0">       """</pre>
-                </td>
-            </tr>
+                    <br/>
+                    <pre style="color: black; margin: 0">{{ escape(step['text']) }}</pre>
             {% endif %}
             {% if step['table'] %}
-            <tr class="d-flex">
-                <td class="col-8" colspan="2">
-                    <pre style="color: black; margin: 0; display: inline">       |</pre>
-                    {% for heading in step['table']['headings'] %}
-                    <pre style="color: black; margin: 0; display: inline">{{ heading }} |</pre>
-                    {% endfor %}
-                    </br>
-                    {% for row in step['table']['rows'] %}
-                        <pre style="color: black; margin: 0; display: inline">       |</pre>
-                        {% for value in row %}
-                        <pre class="text-wrap" style="color: black; margin: 0; display: inline"> {{ value }} |</pre>
-                        {% endfor %}
-                        </br>
-                    {% endfor %}
-                </td>
-            </tr>
+                    <br/>
+                    <pre style="color: black; margin: 0">{{ escape(step['table']) }}</pre>
             {% endif %}
+                </td>
+                <td><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
+            </tr>
             {% if step['result'] is defined %}
                 {% if step['result']['stdout'] %}
                     {% for line in step['result']['stdout'] %}
                     <tr class="d-flex">
                         <td class="col-8" colspan="2" class="text-truncate">
-                            <pre style="color: darkgray;">{{ escape(line) }}</pre>
+                            <span style="color: darkgray;">{{ escape(line) }}</span>
                         </td>
                     </tr>
                     {% endfor %}
@@ -146,11 +117,9 @@
 
             {% if step['result'] is defined %}
                 {% if step['result']['error_message'] %}
-                    {% for line in step['result']['error_message'] %}
-                    <tr class="d-flex">
-                        <td class="col-8" colspan="2" style="margin: 0"><pre style="color: gray; margin: 0">{{ escape(line) }}</pre></td>
-                    </tr>
-                    {% endfor %}
+                    <tr class="d-flex"><td class="col-8" colspan="2" style="margin: 0">
+                        <pre style="color: gray; margin: 0">{{ escape("\n".join(step['result']['error_message'])) }}</pre><br/>
+                    </td></tr>
                 {% endif %}
 
             {% endif %}

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -92,16 +92,18 @@
                     <br/>
                     <pre style="color: black; margin: 0">{{ escape(step['table']) }}</pre>
             {% endif %}
+                </td>
+                <td style="min-width: 0;" class="col-4"><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
+            </tr>
             {% if step['result'] is defined %}
                 {% if step['result']['stdout'] %}
-                    <pre style="color: darkgray;">{{ escape("\n".join(step['result']['stdout'])) }}</pre>
+                    <tr class="d-flex"><td style="min-width: 0;" class="col-12" colspan="2" style="margin: 0">
+                        <pre style="color: darkgray;">{{ escape("\n".join(step['result']['stdout'])) }}</pre>
+                    </td></tr>
                     {% for line in step['result']['stdout'] %}
                     {% endfor %}
                 {% endif %}
             {% endif %}
-                </td>
-                <td style="min-width: 0;" class="col-4"><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
-            </tr>
 
             {% if step['image'] is defined and step['result'] is defined %}
             <tr class="d-flex">
@@ -113,7 +115,7 @@
 
             {% if step['result'] is defined %}
                 {% if step['result']['error_message'] is defined %}
-                    <tr class="d-flex"><td style="min-width: 0;" class="col-8" colspan="2" style="margin: 0">
+                    <tr class="d-flex"><td style="min-width: 0;" class="col-12" colspan="2" style="margin: 0">
                         <pre style="color: gray; margin: 0">{{ escape("\n".join(step['result']['error_message'])) }}</pre><br/>
                     </td></tr>
                 {% endif %}

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -62,7 +62,7 @@
             <td style="min-width: 0;" class="col-8 text-truncate">
                 <span style="display: inline; color: maroon;">Feature: </span> {{ escape(feature['name']) }}<br/>
                 <span style="display: inline; color: mediumturquoise">{{ feature['tags'] }}</span><br/>
-                <span style="display: inline; color: maroon;">Scenario:</span> {{ escape(scenario['name']) }}
+                <span style="display: inline; color: maroon;">Scenario:</span> {{ escape(scenario['name']) }}<br/>
                 <span style="display: inline; color: mediumturquoise">{{ scenario['tags'] }}</span><br/>
             </td>
             <td style="min-width: 0;" class="col-4 text-truncate" style="color: gray;"></td>

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -83,7 +83,7 @@
             <tr class="d-flex">
                 <td class="anchor-toggle text-truncate col-8" data-toggle="collapse" href="#collapsable-row-{{ loop.index }}" role="button" aria-expanded="false" aria-controls="collapsable-row-{{ loop.index }}">
                     <a class="anchor" id="step_{{ loop.index}}" href="#step_{{ loop.index }}">🔗</a>
-                    <pre class="status-{{ step_status }}">{{ step_keyword }}</pre><span> {{ escape(step['name']) }}</span>
+                    <pre class="status-{{ step_status }}">{{ step_keyword }}</pre><span style="display: contents;"> {{ escape(step['name']) }}</span>
             {% if step['text'] %}
                     <br/>
                     <pre style="color: black; margin: 0">{{ escape(step['text']) }}</pre>
@@ -100,7 +100,7 @@
                 {% endif %}
             {% endif %}
                 </td>
-                <td><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
+                <td class="col-4"><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
             </tr>
 
             {% if step['image'] is defined and step['result'] is defined %}

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -105,7 +105,7 @@
 
             {% if step['image'] is defined and step['result'] is defined %}
             <tr class="d-flex">
-                <td class="col-8 collapse multi-collapse" id="collapsable-row-{{ loop.index }}" colspan="2">
+                <td class="col-12 collapse multi-collapse" id="collapsable-row-{{ loop.index }}" colspan="2">
                     <img class="col-11 mx-auto d-block img-fluid shadow bg-white rounded" alt='{{ step_name }}' title='{{ step_name }}' src='{{ step["image"] }}'></img>
                 </td>
             </tr>

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -57,11 +57,11 @@
     <table class="table table-borderless">
         <tr class="remove-table-hover"><span style="display: inline; color: mediumturquoise">{{ feature['tags'] }} {{ scenario['tags'] }}</span><br/></tr>
         <tr class="d-flex">
-            <td class="col-8 text-truncate">
+            <td style="min-width: 0;" class="col-8 text-truncate">
                 <span style="display: inline; color: maroon;">Feature: </span> {{ escape(feature['name']) }}<br/>
                 <span style="display: inline; color: maroon;">Scenario:</span> {{ escape(scenario['name']) }}
             </td>
-            <td class="col-4 text-truncate" style="color: gray;"></td>
+            <td style="min-width: 0;" class="col-4 text-truncate" style="color: gray;"></td>
         </tr>
         {% for step in steps %}
             {% set step_name = step['keyword'] + ' ' + escape(step['name']) %}
@@ -81,7 +81,7 @@
             {% endif %}
             {% set step_keyword = step_prefix + step['keyword'].rjust(6, ' ') %}
             <tr class="d-flex">
-                <td class="anchor-toggle text-truncate col-8" data-toggle="collapse" href="#collapsable-row-{{ loop.index }}" role="button" aria-expanded="false" aria-controls="collapsable-row-{{ loop.index }}">
+                <td style="min-width: 0;" class="anchor-toggle text-truncate col-8" data-toggle="collapse" href="#collapsable-row-{{ loop.index }}" role="button" aria-expanded="false" aria-controls="collapsable-row-{{ loop.index }}">
                     <a class="anchor" id="step_{{ loop.index}}" href="#step_{{ loop.index }}">🔗</a>
                     <pre class="status-{{ step_status }}">{{ step_keyword }}</pre><span style="display: contents;"> {{ escape(step['name']) }}</span>
             {% if step['text'] %}
@@ -100,12 +100,12 @@
                 {% endif %}
             {% endif %}
                 </td>
-                <td class="col-4"><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
+                <td style="min-width: 0;" class="col-4"><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
             </tr>
 
             {% if step['image'] is defined and step['result'] is defined %}
             <tr class="d-flex">
-                <td class="col-12 collapse multi-collapse" id="collapsable-row-{{ loop.index }}" colspan="2">
+                <td style="min-width: 0;" class="col-12 collapse multi-collapse" id="collapsable-row-{{ loop.index }}" colspan="2">
                     <img class="col-11 mx-auto d-block img-fluid shadow bg-white rounded" alt='{{ step_name }}' title='{{ step_name }}' src='{{ step["image"] }}'></img>
                 </td>
             </tr>
@@ -113,7 +113,7 @@
 
             {% if step['result'] is defined %}
                 {% if step['result']['error_message'] is defined %}
-                    <tr class="d-flex"><td class="col-8" colspan="2" style="margin: 0">
+                    <tr class="d-flex"><td style="min-width: 0;" class="col-8" colspan="2" style="margin: 0">
                         <pre style="color: gray; margin: 0">{{ escape("\n".join(step['result']['error_message'])) }}</pre><br/>
                     </td></tr>
                 {% endif %}

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -112,7 +112,7 @@
             {% if step['image'] is defined and step['result'] is defined %}
             <tr class="row">
                 <td style="min-width: 0;" class="col-12 collapse multi-collapse" id="collapsable-row-{{ loop.index }}" colspan="2">
-                    <img class="col-11 mx-auto d-block img-fluid shadow bg-white rounded" alt='{{ step_name }}' title='{{ step_name }}' src='{{ step["image"] }}'></img>
+                    <img class="mx-auto d-block img-fluid shadow bg-white rounded" alt='{{ step_name }}' title='{{ step_name }}' src='{{ step["image"] }}'></img>
                 </td>
             </tr>
             {% endif %}

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -55,7 +55,7 @@
     }
     </style>
     <table class="table table-borderless">
-        <tr class="remove-table-hover"><pre style="display: inline; color: mediumturquoise">{{ scenario['tags'] }}</pre><br/></tr>
+        <tr class="remove-table-hover"><pre style="display: inline; color: mediumturquoise">{{ feature['tags'] }} {{ scenario['tags'] }}</pre><br/></tr>
         <tr class="d-flex">
             <td class="col-8 text-truncate">
                 <pre style="display: inline; color: maroon;">Scenario:</pre> {{ escape(scenario['name']) }}

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -2,7 +2,7 @@
 {% block content %}
     <nav class="navbar navbar-expand-sm sticky-top navbar-light bg-light">
         <div class="container-fluid">
-            <a class="navbar-brand" href="#">HTML Test Report</a>
+            <a class="navbar-brand" href="#">Scenario HTML Test Report</a>
 
             <div class="collapse navbar-collapse">
               <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
@@ -58,6 +58,7 @@
         <tr class="remove-table-hover"><pre style="display: inline; color: mediumturquoise">{{ feature['tags'] }} {{ scenario['tags'] }}</pre><br/></tr>
         <tr class="d-flex">
             <td class="col-8 text-truncate">
+                <pre style="display: inline; color: maroon;">Feature: </pre> {{ escape(feature['name']) }}<br/>
                 <pre style="display: inline; color: maroon;">Scenario:</pre> {{ escape(scenario['name']) }}
             </td>
             <td class="col-4 text-truncate" style="color: gray;"></td>

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -92,20 +92,16 @@
                     <br/>
                     <pre style="color: black; margin: 0">{{ escape(step['table']) }}</pre>
             {% endif %}
-                </td>
-                <td><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
-            </tr>
             {% if step['result'] is defined %}
                 {% if step['result']['stdout'] %}
+                    <pre style="color: darkgray;">{{ escape("\n".join(step['result']['stdout'])) }}</pre>
                     {% for line in step['result']['stdout'] %}
-                    <tr class="d-flex">
-                        <td class="col-8" colspan="2" class="text-truncate">
-                            <span style="color: darkgray;">{{ escape(line) }}</span>
-                        </td>
-                    </tr>
                     {% endfor %}
                 {% endif %}
             {% endif %}
+                </td>
+                <td><span style="display: inline; color: gray;">{{ step_timing }}</span></td>
+            </tr>
 
             {% if step['image'] is defined and step['result'] is defined %}
             <tr class="d-flex">

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% block content %}
+{% block nav %}
     <nav class="navbar navbar-expand-sm sticky-top navbar-light bg-light">
         <div class="container-fluid">
             <a class="navbar-brand" href="#">Scenario HTML Test Report</a>
@@ -38,6 +38,8 @@
             </div>
         </div>
     </nav>
+{% endblock %}
+{% block content %}
     <style>
     .anchor {
       display: inline;

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -116,13 +116,13 @@
             {% endif %}
 
             {% if step['result'] is defined %}
-                {% if step['result']['error_message'] %}
+                {% if step['result']['error_message'] is defined %}
                     <tr class="d-flex"><td class="col-8" colspan="2" style="margin: 0">
                         <pre style="color: gray; margin: 0">{{ escape("\n".join(step['result']['error_message'])) }}</pre><br/>
                     </td></tr>
                 {% endif %}
-
             {% endif %}
+
         {% endfor %}
     </table>
     <script>

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -56,7 +56,7 @@
       visibility: visible;
     }
     </style>
-    <table class="table table-borderless container">
+    <table class="table table-borderless container row">
 
         <tr class="row">
             <td style="min-width: 0;" class="col-8 text-truncate">

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -54,12 +54,14 @@
       visibility: visible;
     }
     </style>
-    <table class="table table-borderless">
-        <tr class="remove-table-hover"><span style="display: inline; color: mediumturquoise">{{ feature['tags'] }} {{ scenario['tags'] }}</span><br/></tr>
-        <tr class="d-flex">
+    <table class="table table-borderless container">
+
+        <tr class="row">
             <td style="min-width: 0;" class="col-8 text-truncate">
                 <span style="display: inline; color: maroon;">Feature: </span> {{ escape(feature['name']) }}<br/>
+                <span style="display: inline; color: mediumturquoise">{{ feature['tags'] }}</span><br/>
                 <span style="display: inline; color: maroon;">Scenario:</span> {{ escape(scenario['name']) }}
+                <span style="display: inline; color: mediumturquoise">{{ scenario['tags'] }}</span><br/>
             </td>
             <td style="min-width: 0;" class="col-4 text-truncate" style="color: gray;"></td>
         </tr>
@@ -80,7 +82,7 @@
                 {% set step_timing = "" %}
             {% endif %}
             {% set step_keyword = step_prefix + step['keyword'].rjust(6, ' ') %}
-            <tr class="d-flex">
+            <tr class="row">
                 <td style="min-width: 0;" class="anchor-toggle text-truncate col-8" data-toggle="collapse" href="#collapsable-row-{{ loop.index }}" role="button" aria-expanded="false" aria-controls="collapsable-row-{{ loop.index }}">
                     <a class="anchor" id="step_{{ loop.index}}" href="#step_{{ loop.index }}">🔗</a>
                     <pre class="status-{{ step_status }}">{{ step_keyword }}</pre><span style="display: contents;"> {{ escape(step['name']) }}</span>
@@ -97,7 +99,7 @@
             </tr>
             {% if step['result'] is defined %}
                 {% if step['result']['stdout'] %}
-                    <tr class="d-flex"><td style="min-width: 0;" class="col-12" colspan="2" style="margin: 0">
+                    <tr class="row"><td style="min-width: 0;" class="col-12" colspan="2" style="margin: 0">
                         <pre style="color: darkgray;">{{ escape("\n".join(step['result']['stdout'])) }}</pre>
                     </td></tr>
                     {% for line in step['result']['stdout'] %}
@@ -106,7 +108,7 @@
             {% endif %}
 
             {% if step['image'] is defined and step['result'] is defined %}
-            <tr class="d-flex">
+            <tr class="row">
                 <td style="min-width: 0;" class="col-12 collapse multi-collapse" id="collapsable-row-{{ loop.index }}" colspan="2">
                     <img class="col-11 mx-auto d-block img-fluid shadow bg-white rounded" alt='{{ step_name }}' title='{{ step_name }}' src='{{ step["image"] }}'></img>
                 </td>
@@ -115,7 +117,7 @@
 
             {% if step['result'] is defined %}
                 {% if step['result']['error_message'] is defined %}
-                    <tr class="d-flex"><td style="min-width: 0;" class="col-12" colspan="2" style="margin: 0">
+                    <tr class="row"><td style="min-width: 0;" class="col-12" colspan="2" style="margin: 0">
                         <pre style="color: gray; margin: 0">{{ escape("\n".join(step['result']['error_message'])) }}</pre><br/>
                     </td></tr>
                 {% endif %}

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -83,7 +83,7 @@
             <tr class="d-flex">
                 <td class="anchor-toggle text-truncate col-8" data-toggle="collapse" href="#collapsable-row-{{ loop.index }}" role="button" aria-expanded="false" aria-controls="collapsable-row-{{ loop.index }}">
                     <a class="anchor" id="step_{{ loop.index}}" href="#step_{{ loop.index }}">🔗</a>
-                    <pre class="status-{{ step_status }}">{{ step_keyword }}</pre><span class="status-{{ step['result'] }}"> {{ escape(step['name']) }}</span>
+                    <pre class="status-{{ step_status }}">{{ step_keyword }}</pre><span> {{ escape(step['name']) }}</span>
             {% if step['text'] %}
                     <br/>
                     <pre style="color: black; margin: 0">{{ escape(step['text']) }}</pre>

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -31,6 +31,9 @@
                 <li class="nav-item active">
                     <button class="btn btn-md btn-light" title="scroll to bottom" onclick="window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });" class="nav-link">⬇️ </button>
                 </li>
+                <li class="align-middle">
+                    <span style="vertical-align: -webkit-baseline-middle;">Started at: {{ scenario["started_at"] }}, Duration: {{ '{:.3f}'.format(scenario['duration']) }}s</span>
+                </li>
               </ul>
             </div>
         </div>


### PR DESCRIPTION
* fix report html width so it doesn’t make images huge
* default not to show skips
   * merge skip config into one flag
* fix cucu debug command
* default not to show status for report generation
   * add newline after report generation status
* add start timestamp to scenario, feature and index
* add static totals to index and feature pages
* don't search on timestamps and totals in report pages - see https://datatables.net/plug-ins/filtering/
* add flat index page that shows all scenarios
* add feature tags and name  to scenario page
* reduce extraneous tags in scenario page
   * move text and table into same step td
   * have only 1 pre tag for each text, table, stdout and error_message

Note that there is an issue with **flexbox** and **white-space: nowrap** in browsers that makes them hard to be compatible. The workaround is setting **min-width: 0;**  on the flexbox’s immediate children. This doesn’t seem to work well with what we have though (bootstrap + table + bootstraps’s grid).

https://dominodatalab.atlassian.net/browse/QE-10656
https://stackoverflow.com/questions/38223879/white-space-nowrap-breaks-flexbox-layout
https://getbootstrap.com/docs/5.1/layout/grid/
https://getbootstrap.com/docs/4.0/utilities/flex/

# Where to look
Look at the test result html report for these scenarios
1. User can verify visibility of an nth button => look at the stdout (directly under the step) and error_message (in the sub-step)
2. User can run results without skips in the HTML test report on a feature with background