### PR TITLE
QE-11255 Use tenacity.retry in page checks

### DIFF
--- a/features/flow_control/before_retry_handlers.feature
+++ b/features/flow_control/before_retry_handlers.feature
@@ -40,9 +40,9 @@ Feature: Before retry handlers
 
         Scenario: Scenario with an before retry handler
           Given I start a webserver at directory "data/www" and save the port to the variable "PORT" .*
-      .* INFO handled the pesky button buttons!
             And I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/links.html" .*
             [\s\S]*
+      .* INFO handled the pesky button buttons!
            Then I wait to see the button "button with child" .*
 
       1 feature passed, 0 failed, 0 skipped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.125.0"
+version = "0.126.0"
 license = "MIT"
 description = ""
 authors = ["Rodney Gomes <rodneygomes@gmail.com>"]


### PR DESCRIPTION
cucu's retry function has hooks that are used to run other functions during retry, e.g., disabling toast. Those functions shouldn't be run during page check retry. This PR replaces cucu retry with tenacity.retry in page checks to avoid those hooks.