### PR TITLE
QE-11968 Add more debug logs in cucu steps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.135.0"
+version = "0.136.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Rodney Gomes <rodneygomes@gmail.com>", "Cedric Young <Cedric.Young@dominodatalab.com>"]

--- a/src/cucu/helpers.py
+++ b/src/cucu/helpers.py
@@ -2,7 +2,7 @@ import sys
 
 import humanize
 
-from cucu import retry, run_steps
+from cucu import logger, retry, run_steps
 from cucu.config import CONFIG
 
 
@@ -119,6 +119,7 @@ def define_should_see_thing_with_name_steps(thing, find_func, with_nth=False):
 
         if element is None:
             raise RuntimeError(f'unable to find the {prefix}{thing} "{name}"')
+        logger.debug(f'see {prefix}{thing} "{name}"')
 
     @step(f'I should immediately see the {thing} "{{name}}"')
     def should_immediately_see_the(ctx, thing, name):
@@ -176,6 +177,7 @@ def define_should_see_thing_with_name_steps(thing, find_func, with_nth=False):
 
         if element is not None:
             raise RuntimeError(f'able to find the {prefix}{thing} "{name}"')
+        logger.debug(f'not see {prefix}{thing} "{name}"')
 
     @step(f'I should immediately not see the {thing} "{{name}}"')
     def should_immediately_not_see_the(ctx, thing, name):
@@ -290,6 +292,7 @@ def define_action_on_thing_with_name_steps(
                 )
         else:
             action_func(ctx, element)
+            logger.debug(f'{action} {prefix}{thing} "{name}"')
 
     @step(f'I immediately {action} the {thing} "{{name}}"')
     def immediately_action_the(ctx, name):
@@ -544,6 +547,7 @@ def define_thing_with_name_in_state_steps(
 
         if not is_in_state_func(element):
             raise RuntimeError(f'{thing} "{name}" is not {state}')
+        logger.debug(f"{thing} {name} is {state}")
 
     @step(f'I should immediately see the {thing} "{{name}}" is {state}')
     def should_immedieately_see_the_in_state(ctx, thing, name, state, index=0):

--- a/src/cucu/helpers.py
+++ b/src/cucu/helpers.py
@@ -119,7 +119,7 @@ def define_should_see_thing_with_name_steps(thing, find_func, with_nth=False):
 
         if element is None:
             raise RuntimeError(f'unable to find the {prefix}{thing} "{name}"')
-        logger.debug(f'see {prefix}{thing} "{name}"')
+        logger.debug(f'Success: saw {prefix}{thing} "{name}"')
 
     @step(f'I should immediately see the {thing} "{{name}}"')
     def should_immediately_see_the(ctx, thing, name):
@@ -177,7 +177,7 @@ def define_should_see_thing_with_name_steps(thing, find_func, with_nth=False):
 
         if element is not None:
             raise RuntimeError(f'able to find the {prefix}{thing} "{name}"')
-        logger.debug(f'not see {prefix}{thing} "{name}"')
+        logger.debug(f'Success: did not see {prefix}{thing} "{name}"')
 
     @step(f'I should immediately not see the {thing} "{{name}}"')
     def should_immediately_not_see_the(ctx, thing, name):
@@ -292,7 +292,7 @@ def define_action_on_thing_with_name_steps(
                 )
         else:
             action_func(ctx, element)
-            logger.debug(f'{action} {prefix}{thing} "{name}"')
+            logger.debug(f'Successfully executed {action} {prefix}{thing} "{name}"')
 
     @step(f'I immediately {action} the {thing} "{{name}}"')
     def immediately_action_the(ctx, name):
@@ -547,7 +547,7 @@ def define_thing_with_name_in_state_steps(
 
         if not is_in_state_func(element):
             raise RuntimeError(f'{thing} "{name}" is not {state}')
-        logger.debug(f"{thing} {name} is {state}")
+        logger.debug(f'{thing} {name} was in desired state "{state}"')
 
     @step(f'I should immediately see the {thing} "{{name}}" is {state}')
     def should_immedieately_see_the_in_state(ctx, thing, name, state, index=0):

--- a/src/cucu/helpers.py
+++ b/src/cucu/helpers.py
@@ -292,7 +292,9 @@ def define_action_on_thing_with_name_steps(
                 )
         else:
             action_func(ctx, element)
-            logger.debug(f'Successfully executed {action} {prefix}{thing} "{name}"')
+            logger.debug(
+                f'Successfully executed {action} {prefix}{thing} "{name}"'
+            )
 
     @step(f'I immediately {action} the {thing} "{{name}}"')
     def immediately_action_the(ctx, name):

--- a/src/cucu/logger.py
+++ b/src/cucu/logger.py
@@ -46,6 +46,18 @@ def init_debug_logger(output_file):
     logging.getLogger().addHandler(handler)
 
 
+@wraps(logging.log)
+def log(*args, **kwargs):
+    console_handler = logging.getLogger().handlers[0]
+    logging_level = console_handler.level
+
+    msg_level = args[0]
+    if logging_level <= msg_level:
+        CONFIG["__CUCU_WROTE_TO_OUTPUT"] = True
+
+    logging.getLogger().log(*args, **kwargs)
+
+
 @wraps(logging.debug)
 def debug(*args, **kwargs):
     console_handler = logging.getLogger().handlers[0]

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -2,11 +2,20 @@
 various cucu utilities can be placed here and then exposed publicly through
 the src/cucu/__init__.py
 """
+import logging
 
 from tabulate import DataRow, TableFormat, tabulate
-from tenacity import retry as retrying
-from tenacity import retry_if_not_exception_type, stop_after_delay, wait_fixed
+from tenacity import (
+    before_sleep_log,
+    retry_if_not_exception_type,
+    stop_after_delay,
+    wait_fixed,
+)
+from tenacity import (
+    retry as retrying,
+)
 
+from cucu import logger
 from cucu.config import CONFIG
 
 GHERKIN_TABLEFORMAT = TableFormat(
@@ -103,6 +112,7 @@ def retry(func, wait_up_to_s=None, retry_after_s=None):
         stop=stop_after_delay(wait_up_to_s),
         wait=wait_fixed(retry_after_s),
         retry=retry_if_not_exception_type(StopRetryException),
+        before_sleep=before_sleep_log(logger, logging.DEBUG),
     )
     def new_decorator(*args, **kwargs):
         ctx = CONFIG["__CUCU_CTX"]


### PR DESCRIPTION
Add more logs in retries and after cucu finishes an action. Some example:
<img width="1190" alt="image" src="https://github.com/cerebrotech/cucu/assets/104880864/982efff9-f5aa-4971-b6e1-51baca09ca99">
