### PR TITLE
QE-11489 Add table indices to error output

### DIFF
--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -239,20 +239,21 @@ Feature: Run outputs
      Then I run the command "cucu run {CUCU_RESULTS_DIR}/tables_in_output/tables_in_output.feature --results {CUCU_RESULTS_DIR}/tables_in_output_results" and save stdout to "STDOUT" and expect exit code "1"
       And I should see "{STDOUT}" contains the following
       """
+      "1st" table:
       | Name   | City          | Country       |
       | Alfred | Berlin        | Germany       |
       | Joe    | San Francisco | United States |
       | Maria  | Cancun        | Mexico        |
-
+      "2nd" table:
       | Name   | Age |
       | Alfred | 31  |
       | Joe    | 35  |
       | Maria  | 33  |
-
+      "3rd" table:
       | Name (last name optional) | Age (in years) |
       | Alfred                    | 31             |
       | Maria Lopez               | 33             |
-
+      "4th" table:
       | User Title   | Yearly Salary |
       | Alfred White | 120,000       |
       | Maria Lopez  | 133,000       |

--- a/src/cucu/steps/table_steps.py
+++ b/src/cucu/steps/table_steps.py
@@ -110,8 +110,8 @@ def report_unable_to_find_table(tables):
     stream = StringIO()
     stream.write("\n")
     for index, table in enumerate(tables):
-        print_index = helpers.nth_to_ordinal(index) or '"1st"'
-        stream.write(f"{print_index} table:\n{format_gherkin_table(table)}\n")
+        print_index = helpers.nth_to_ordinal(index) or '"1st" '
+        stream.write(f"{print_index}table:\n{format_gherkin_table(table)}\n")
 
     stream.seek(0)
     raise RuntimeError(f"unable to find desired table, found: {stream.read()}")


### PR DESCRIPTION
This answers to poinst (1) and (3) in [QE-11489](https://dominodatalab.atlassian.net/browse/QE-11489) (I think). Point (2) is more involved, because it involves hacking Behave's standard table output to get our variable interpolation in there, and I'm not sure we actually want that.

But replacing blank lines with indices is easy enough.

[QE-11489]: https://dominodatalab.atlassian.net/browse/QE-11489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ