### PR TITLE
QE-12150 Add an option to tighten fuzzy find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.156.0
+- Add - option to only find web elements with the name inside in fuzzy find
+- Change - when finding dropdown options when the dropdown is not a select element, only considers name inside option
+
 ## 0.155.0
 - Add - timestamp toolip to steps in html report
 

--- a/data/www/fuzzy_rules.html
+++ b/data/www/fuzzy_rules.html
@@ -42,5 +42,22 @@
             </div>
         </div>
     </div>
+    <div>
+      <ul>
+        <li>Grape</li>
+        <li>Apple</li>
+      </ul>
+    </div>
+    <label for="colors">Pick a color</label>
+    <div class="combo-wrap">
+      <input type="text" id="colors" role="combobox" aria-controls="color-names" aria-autocomplete="list" aria-expanded="false"
+        data-active-option="item1" aria-activedescendant="" />
+      <span aria-hidden="true" data-trigger="multiselect"></span>
+      <ul id="color-names" role="listbox" aria-label="colors">
+        <li class="active" role="option" id="item1">Red</li>
+        <li class="option" role="option" id="item2">Blue</li>
+        <li class="option" role="option" id="item3">Orange</li>
+      </ul>
+    </div>
   </body>
 </html>

--- a/features/browser/fuzzy_rules.feature
+++ b/features/browser/fuzzy_rules.feature
@@ -18,3 +18,8 @@ Feature: Fuzzy rules
      Then I should see "button with placeholder" in the input "value:"
      When I click the button "button with previous nested sibling label"
      Then I should see "button with previous nested sibling label" in the input "value:"
+     When I should see the dropdown "Pick a color"
+     Then I wait up to "1" seconds to see the following steps fail
+       """
+       When I select the option "Apple" from the dropdown "Pick a color"
+       """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.155.0"
+version = "0.156.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/fuzzy/core.py
+++ b/src/cucu/fuzzy/core.py
@@ -49,7 +49,14 @@ class Direction(Enum):
     RIGHT_TO_LEFT = 2
 
 
-def find(browser, name, things, index=0, direction=Direction.LEFT_TO_RIGHT):
+def find(
+    browser,
+    name,
+    things,
+    index=0,
+    direction=Direction.LEFT_TO_RIGHT,
+    name_within_thing=False,
+):
     """
     find an element by applying the fuzzy finding rules when given the name
     that identifies the element on screen and a list of possible `things` that
@@ -61,15 +68,16 @@ def find(browser, name, things, index=0, direction=Direction.LEFT_TO_RIGHT):
     input[type='button'], etc.
 
     parameters:
-      browser   - the cucu.browser.Browser object
-      name      - name that identifies the element you are trying to find
-      things    - array of CSS fragments that specify the kind of elements you
-                  want to match on
-      index     - which of the many matches to return
-      direction - the text to element direction to apply fuzzy in. Default we
-                  apply right to left but for checkboxes or certain languages
-                  this direction can be used to find things by prioritizing
-                  matching from "left to right"
+      browser           - the cucu.browser.Browser object
+      name              - name that identifies the element you are trying to find
+      things            - array of CSS fragments that specify the kind of elements you
+                          want to match on
+      index             - which of the many matches to return
+      direction         - the text to element direction to apply fuzzy in. Default we
+                          apply right to left but for checkboxes or certain languages
+                          this direction can be used to find things by prioritizing
+                          matching from "left to right"
+      name_within_thing - to determine if the name has to be within the web element
 
     returns:
         the WebElement that matches the provided arguments.
@@ -80,12 +88,14 @@ def find(browser, name, things, index=0, direction=Direction.LEFT_TO_RIGHT):
     # we pass arguments to the fuzzy_find javascript function wrapped in double
     # quotes
     name = name.replace('"', '\\"')
+    name_within_thing = "true" if name_within_thing else "false"
 
     args = [
         f'"{name}"',
         str(things),
         str(index),
         str(direction.value),
+        name_within_thing,
     ]
 
     def execute_fuzzy_find():

--- a/src/cucu/fuzzy/fuzzy.js
+++ b/src/cucu/fuzzy/fuzzy.js
@@ -40,19 +40,21 @@
      * input[type='button'], etc.
      *
      * parameters:
-     *   name           - name that identifies the element you are trying to find
-     *   things         - array of CSS fragments that specify the kind of elements
-     *                    you want to match on
-     *   index          - which of the many matches to return
-     *   direction      - the text to element direction to apply fuzzy in. Default
-     *                    we apply right to left but for checkboxes or certain
-     *                    languages this direction can be used to find things by
-     *                    prioritizing matching from "left to right"
+     *   name              - name that identifies the element you are trying to find
+     *   things            - array of CSS fragments that specify the kind of elements
+     *                       you want to match on
+     *   index             - which of the many matches to return
+     *   direction         - the text to element direction to apply fuzzy in. Default
+     *                       we apply right to left but for checkboxes or certain
+     *                       languages this direction can be used to find things by
+     *                       prioritizing matching from "left to right"
+     *   name_within_thing - to determine if the name has to be within the web element
      */
     cucu.fuzzy_find = function(name,
                                things,
                                index=0,
-                               direction=LEFT_TO_RIGHT) {
+                               direction=LEFT_TO_RIGHT,
+                               name_within_thing=false) {
         var elements = [];
         var results = null;
         var attributes = ['aria-label', 'title', 'placeholder', 'value'];
@@ -160,6 +162,11 @@
                     if (cucu.debug) { console.log('<thing><* attibute="name"></*></thing>', results); }
                     elements = elements.concat(results);
                 }
+            }
+
+            // if the name has to be within the element, the following rules are not considered
+            if (name_within_thing) {
+                continue;
             }
 
             // element labeled with direct previous sibling

--- a/src/cucu/steps/dropdown_steps.py
+++ b/src/cucu/steps/dropdown_steps.py
@@ -37,11 +37,6 @@ def find_dropdown(ctx, name, index=0):
         direction=fuzzy.Direction.LEFT_TO_RIGHT,
     )
 
-    prefix = "" if index == 0 else f"{humanize.ordinal(index)} "
-
-    if dropdown is None:
-        raise RuntimeError(f"unable to find the {prefix}dropdown {name}")
-
     return dropdown
 
 
@@ -71,6 +66,7 @@ def find_dropdown_option(ctx, name, index=0):
         ],
         index=index,
         direction=fuzzy.Direction.LEFT_TO_RIGHT,
+        name_within_thing=True,
     )
 
     prefix = "" if index == 0 else f"{humanize.ordinal(index)} "
@@ -94,6 +90,10 @@ def find_n_select_dropdown_option(ctx, dropdown, option, index=0):
     ctx.check_browser_initialized()
 
     dropdown_element = find_dropdown(ctx, dropdown, index)
+
+    if dropdown_element is None:
+        prefix = "" if index == 0 else f"{humanize.ordinal(index)} "
+        raise RuntimeError(f"unable to find the {prefix}dropdown {dropdown}")
 
     if base_steps.is_disabled(dropdown_element):
         raise RuntimeError(

--- a/src/cucu/steps/dropdown_steps.py
+++ b/src/cucu/steps/dropdown_steps.py
@@ -42,7 +42,8 @@ def find_dropdown(ctx, name, index=0):
 
 def find_dropdown_option(ctx, name, index=0):
     """
-    find a dropdown option with the provided name
+    find a dropdown option with the provided name. It only considers
+    the web element with the name inside the element.
 
         * <option>
         * <* role="option">


### PR DESCRIPTION
Add an option in `fuzzy.find()` such that it only finds the elements with the name inside the element. This is useful for `option` elements and may also be used in `button` element in the future. 