### PR TITLE
QE-13274 Enable color output in logs when running in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ commands:
           command: poetry run cucu run features --workers 8 --selenium-remote-url http://localhost:4444 --generate-report --junit junit_results --browser "<< parameters.browser >>"
           environment:
             COVERAGE_PROCESS_START: pyproject.toml  # set to config file
-            CUCU_COLOR_OUTPUT: false
 
   run_unit_tests: &run_unit_tests
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.162.0
+- Change - enable color output in cucu logs when running in parallel
+
 ## 0.161.0
 - Change - add .txt as browser console log file suffix
 

--- a/features/cli/config.feature
+++ b/features/cli/config.feature
@@ -35,7 +35,7 @@ Feature: Config
            And I echo "\{FIZZ\}"
            And I echo "\{BUZZ\}"
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/load/nested/cucurc --results={CUCU_RESULTS_DIR}/nested_cucurc_from_parent_directory_results --env BUZZ=buzz" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/load/nested/cucurc --results={CUCU_RESULTS_DIR}/nested_cucurc_from_parent_directory_results --env BUZZ=buzz --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following:
        """
        Feature: Feature file that prints some variables
@@ -59,7 +59,7 @@ Feature: Config
        3 steps passed, 0 failed, 0 skipped, 0 undefined
        [\s\S]*
        """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/load --results={CUCU_RESULTS_DIR}/nested_cucurc_from_top_level_directory_results --env BUZZ=buzz" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/load --results={CUCU_RESULTS_DIR}/nested_cucurc_from_top_level_directory_results --env BUZZ=buzz --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following:
        """
        Feature: Feature file that prints some variables
@@ -113,7 +113,7 @@ Feature: Config
            And I echo "\{FIZZ\}"
            And I echo "\{BUZZ\}"
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/load_nested_cucurc_with_workers --results={CUCU_RESULTS_DIR}/nested_cucurc_with_workers_results --env BUZZ=buzz --workers 2" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/load_nested_cucurc_with_workers --results={CUCU_RESULTS_DIR}/nested_cucurc_with_workers_results --env BUZZ=buzz --workers 2 --no-color-output" and expect exit code "0"
      Then I should see the file at "{CUCU_RESULTS_DIR}/nested_cucurc_with_workers_results/Feature file that prints some variables.log" matches the following:
        """
        Feature: Feature file that prints some variables

--- a/features/cli/run.feature
+++ b/features/cli/run.feature
@@ -17,7 +17,7 @@ Feature: Run
       """
 
   Scenario: User can stop the test execution upon the first failure
-    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --fail-fast --results {CUCU_RESULTS_DIR}/fail_fast_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --fail-fast --results {CUCU_RESULTS_DIR}/fail_fast_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
      Then I should not see the directory at "{CUCU_RESULTS_DIR}/passing_feature_dry_run_results"
       And I should see "{STDOUT}" matches the following
       """
@@ -44,7 +44,7 @@ Feature: Run
       """
 
   Scenario: User can run a specific scenario by name
-    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --name 'Scenario that also passes' --results {CUCU_RESULTS_DIR}/run_by_name_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_mixed_results.feature --name 'Scenario that also passes' --results {CUCU_RESULTS_DIR}/run_by_name_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should not see the directory at "{CUCU_RESULTS_DIR}/passing_feature_dry_run_results"
       And I should see "{STDOUT}" matches the following
       """

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -3,7 +3,7 @@ Feature: Run outputs
   when running with certain flags/feature files.
 
   Scenario: User can --dry-run a passing scenario
-    Given I run the command "cucu run data/features/feature_with_passing_scenario.feature --dry-run --results {CUCU_RESULTS_DIR}/passing_feature_dry_run_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_passing_scenario.feature --dry-run --results {CUCU_RESULTS_DIR}/passing_feature_dry_run_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should not see the directory at "{CUCU_RESULTS_DIR}/passing_feature_dry_run_results"
       And I should see "{STDOUT}" matches the following
       """
@@ -21,7 +21,7 @@ Feature: Run outputs
       And I should see "{STDERR}" is empty
 
   Scenario: User gets expected output when running steps with substeps
-    Given I run the command "cucu run data/features/scenario_with_substeps.feature --results {CUCU_RESULTS_DIR}/substeps-results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/scenario_with_substeps.feature --results {CUCU_RESULTS_DIR}/substeps-results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       [\s\S]*
@@ -41,7 +41,7 @@ Feature: Run outputs
       And I should see "{STDERR}" is empty
 
   Scenario: User gets expected non zero exit code when a scenario fails
-    Given I run the command "cucu run data/features/feature_with_failing_scenario.feature --results {CUCU_RESULTS_DIR}/failing-scenario-results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+    Given I run the command "cucu run data/features/feature_with_failing_scenario.feature --results {CUCU_RESULTS_DIR}/failing-scenario-results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
      Then I should see "{STDOUT}" matches the following
       """
       [\s\S]*
@@ -68,7 +68,7 @@ Feature: Run outputs
       """
 
   Scenario: User can run a scenario with background which uses a step with substeps
-    Given I run the command "cucu run data/features/feature_with_background_using_substeps.feature --results {CUCU_RESULTS_DIR}/background-with-substeps-results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_background_using_substeps.feature --results {CUCU_RESULTS_DIR}/background-with-substeps-results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       Feature: Feature with background using substeps
@@ -99,7 +99,7 @@ Feature: Run outputs
       And I should see "{STDERR}" is empty
 
   Scenario: User can run a scenario with various types of output and see the variable values expanded at runtime
-    Given I run the command "cucu run data/features/feature_with_multilines_and_tables.feature --results {CUCU_RESULTS_DIR}/variable_values_expanded_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_multilines_and_tables.feature --results {CUCU_RESULTS_DIR}/variable_values_expanded_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
       And I should see "{STDOUT}" matches the following
       """
       Feature: Feature with multilines and tables

--- a/features/cli/run_with_hooks.feature
+++ b/features/cli/run_with_hooks.feature
@@ -40,7 +40,7 @@ Feature: Run with hooks
           Given I echo "Hello"
             And I echo "World"
       """
-     Then I run the command "cucu run {CUCU_RESULTS_DIR}/custom_hooks/echo.feature --results {CUCU_RESULTS_DIR}/custom_hooks_results/ -l debug" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     Then I run the command "cucu run {CUCU_RESULTS_DIR}/custom_hooks/echo.feature --results {CUCU_RESULTS_DIR}/custom_hooks_results/ -l debug --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
       And I should see "{STDOUT}" matches the following
       """
       [\s\S]*
@@ -101,7 +101,7 @@ Feature: Run with hooks
           Given I run the following steps after the current scenario-1
             And I run the following steps after the current scenario-2
       """
-     Then I run the command "cucu run {CUCU_RESULTS_DIR}/custom_hooks/echo.feature --results {CUCU_RESULTS_DIR}/custom_hooks_results/ -l debug" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     Then I run the command "cucu run {CUCU_RESULTS_DIR}/custom_hooks/echo.feature --results {CUCU_RESULTS_DIR}/custom_hooks_results/ -l debug --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
       And I should see "{STDOUT}" matches the following
       """
       [\s\S]*

--- a/features/cli/run_with_logging.feature
+++ b/features/cli/run_with_logging.feature
@@ -3,7 +3,7 @@ Feature: Run with logging
   --logging-level option
 
   Scenario: User gets does not get debug logging by default
-    Given I run the command "cucu run data/features/feature_with_logging.feature --results {CUCU_RESULTS_DIR}/default-logging-results" and save stdout to "STDOUT" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_logging.feature --results {CUCU_RESULTS_DIR}/default-logging-results --no-color-output" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       Feature: Feature with logging
@@ -22,7 +22,7 @@ Feature: Run with logging
       """
 
   Scenario: User can expose debug logging when they want it
-    Given I run the command "cucu run data/features/feature_with_logging.feature --logging-level debug --results {CUCU_RESULTS_DIR}/debug-logging-results" and save stdout to "STDOUT" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_logging.feature --logging-level debug --results {CUCU_RESULTS_DIR}/debug-logging-results --no-color-output" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       [\s\S]*

--- a/features/cli/run_with_tags.feature
+++ b/features/cli/run_with_tags.feature
@@ -3,7 +3,7 @@ Feature: Run with tags
   run.
 
   Scenario: User can run a specific feature using a tag
-    Given I run the command "cucu run data/features/feature_with_tagging.feature --tags '@second' --show-skips --results {CUCU_RESULTS_DIR}/scenario_with_tag_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_tagging.feature --tags '@second' --show-skips --results {CUCU_RESULTS_DIR}/scenario_with_tag_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       @all
@@ -29,7 +29,7 @@ Feature: Run with tags
       And I should see "{STDERR}" is empty
 
   Scenario: User can exclude a specific feature using a tag
-    Given I run the command "cucu run data/features/feature_with_tagging.feature --tags '~@second' --show-skips --results {CUCU_RESULTS_DIR}/scenario_without_tag_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_tagging.feature --tags '~@second' --show-skips --results {CUCU_RESULTS_DIR}/scenario_without_tag_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       @all

--- a/features/cli/run_with_thread_dumper.feature
+++ b/features/cli/run_with_thread_dumper.feature
@@ -3,7 +3,7 @@ Feature: Run with thread dumper
   get a periodic thread dump which can help debugging issues in CI.
 
   Scenario: User gets a single thread stacktrace dump and cucu exits cleanly
-    Given I run the command "cucu run data/features/echo.feature --results {CUCU_RESULTS_DIR}/thread_dumper_results --periodic-thread-dumper=15" and save stdout to "STDOUT" and expect exit code "0"
+    Given I run the command "cucu run data/features/echo.feature --results {CUCU_RESULTS_DIR}/thread_dumper_results --periodic-thread-dumper=15 --no-color-output" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see the previous step took less than "10" seconds
       And I should see "{STDOUT}" matches the following
       """

--- a/features/cli/vars.feature
+++ b/features/cli/vars.feature
@@ -92,7 +92,7 @@ Feature: Vars
         Scenario: That simply prints a custom variable
           Given I echo "\{CUSTOM_VARIABLE\}"
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/custom_variables/ --results {CUCU_RESULTS_DIR}/custom_variables_results/" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/custom_variables/ --results {CUCU_RESULTS_DIR}/custom_variables_results/ --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
       # can see a built in variable
      Then I should see "{STDOUT}" matches the following
       """

--- a/features/flow_control/before_retry_handlers.feature
+++ b/features/flow_control/before_retry_handlers.feature
@@ -33,7 +33,7 @@ Feature: Before retry handlers
             # the before retry handler will be the one to click and switch to the next tab
            Then I wait to see the button "button with child"
       """
-     Then I run the command "cucu run {CUCU_RESULTS_DIR}/before_retry_handlers --results {CUCU_RESULTS_DIR}/before_retry_handlers_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     Then I run the command "cucu run {CUCU_RESULTS_DIR}/before_retry_handlers --results {CUCU_RESULTS_DIR}/before_retry_handlers_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
       And I should see "{STDOUT}" matches the following
       """
       Feature: Feature with scenarios using before retry handlers

--- a/features/flow_control/run_and_measure.feature
+++ b/features/flow_control/run_and_measure.feature
@@ -22,7 +22,7 @@ Feature: Run and measure
              And I should see the directory at "\{SCENARIO_RESULTS_DIR\}/files/iter-1"
             \"\"\"
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/measuring_following_steps/measuring_feature.feature --results {CUCU_RESULTS_DIR}/measuring_following_steps_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/measuring_following_steps/measuring_feature.feature --results {CUCU_RESULTS_DIR}/measuring_following_steps_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following:
       """
       Feature: Feature that measures a set of steps
@@ -64,7 +64,7 @@ Feature: Run and measure
            Then I should see the directory at "\{SCENARIO_RESULTS_DIR\}/files/iter-1"
             And I stop the timer "Create and Verify Directory"
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/measuring_between_steps/measuring_feature.feature --results {CUCU_RESULTS_DIR}/measuring_between_steps_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/measuring_between_steps/measuring_feature.feature --results {CUCU_RESULTS_DIR}/measuring_between_steps_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following:
       """
       Feature: Feature that measures a set of steps

--- a/features/flow_control/run_scenarios_conditionally.feature
+++ b/features/flow_control/run_scenarios_conditionally.feature
@@ -6,7 +6,7 @@ Feature: Run scenarios conditionally
       And I delete the file at "./skip_second_scenario.txt" if it exists
 
   Scenario: User can run scenarios conditionally based on presence of a file
-    Given I run the command "cucu run data/features/feature_skipping_scenarios_by_file_presence.feature --results {CUCU_RESULTS_DIR}/skip_scenarios_conditionally_results" and save stdout to "STDOUT" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_skipping_scenarios_by_file_presence.feature --results {CUCU_RESULTS_DIR}/skip_scenarios_conditionally_results --no-color-output" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       Feature: Feature with skipping scenarios by file presence
@@ -33,7 +33,7 @@ Feature: Run scenarios conditionally
       """
       bananas
       """
-      And I run the command "cucu run data/features/feature_skipping_scenarios_by_file_presence.feature --results {CUCU_RESULTS_DIR}/skip_first_scenario_results" and save stdout to "STDOUT" and expect exit code "0"
+      And I run the command "cucu run data/features/feature_skipping_scenarios_by_file_presence.feature --results {CUCU_RESULTS_DIR}/skip_first_scenario_results --no-color-output" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       Feature: Feature with skipping scenarios by file presence

--- a/features/os/platform_steps.feature
+++ b/features/os/platform_steps.feature
@@ -3,7 +3,7 @@ Feature: Platform steps
   filesystem
 
   Scenario: User can use platform skipping steps to skip tests correctly
-    Given I run the command "cucu run data/features/feature_with_platform_specific_scenarios.feature --results {CUCU_RESULTS_DIR}/platform_specific_results" and save stdout to "STDOUT" and expect exit code "0"
+    Given I run the command "cucu run data/features/feature_with_platform_specific_scenarios.feature --results {CUCU_RESULTS_DIR}/platform_specific_results --no-color-output" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
       Feature: Feature with passing scenario

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.161.0"
+version = "0.162.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -72,8 +72,7 @@ def behave(
 
     init_page_checks()
 
-    if color_output:
-        os.environ["CUCU_COLOR_OUTPUT"] = str(color_output).lower()
+    os.environ["CUCU_COLOR_OUTPUT"] = str(color_output).lower()
 
     if headless:
         os.environ["CUCU_BROWSER_HEADLESS"] = "True"

--- a/src/cucu/formatter/cucu.py
+++ b/src/cucu/formatter/cucu.py
@@ -35,7 +35,7 @@ class CucuFormatter(Formatter):
         self._multiline_indentation = None
 
         color_output = CONFIG["CUCU_COLOR_OUTPUT"]
-        self.monochrome = not self.stream.isatty() or color_output != "true"
+        self.monochrome = color_output != "true"
 
     @property
     def multiline_indentation(self):


### PR DESCRIPTION
Currently when running in parallel, the cucu logs html files don't have color. With this PR, they will.

The main change is in `src/cucu/cli/run.py` and `src/cucu/formatter/cucu.py`. The rest of the change is to use `--no-color-output` in tests so that the `STDOUT` won't have color marks