### PR TITLE
QE-13684 Fix injecting cucu fuzzy find library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.167.0
+- Fix - fuzzy JS code injection in web page redirection
+
 ## 0.166.0
 - Add - functions and steps for clicking a row in a table
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.166.0"
+version = "0.167.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -194,7 +194,6 @@ class Selenium(Browser):
             raise Exception(f"unknown browser {browser}")
 
         self.driver.set_window_size(width, height)
-        self.wait_for_page_to_load()
 
     def get_log(self):
         if config.CONFIG["CUCU_BROWSER"] == "firefox":

--- a/src/cucu/fuzzy/core.py
+++ b/src/cucu/fuzzy/core.py
@@ -1,6 +1,7 @@
 import pkgutil
 from enum import Enum
 
+from cucu import logger
 from cucu.browser.frames import search_in_all_frames
 
 
@@ -27,17 +28,15 @@ def init(browser):
     parameters:
         browser - ...
     """
-    browser.execute(load_jquery_lib())
+    script = "return typeof cucu !== 'undefined' && typeof cucu.fuzzy_find === 'function';"
+    cucu_injected = browser.execute(script)
+    if cucu_injected:
+        # cucu fuzzy find already exists
+        return
 
-    # to prevent interference with the jQuery used on the web page
-    browser.execute("window.jqCucu = jQuery.noConflict(true);")
-    script = "return window.jqCucu && jqCucu.fn.jquery;"
-    jquery_version = browser.execute(script)
-
-    while jquery_version is None or not jquery_version.startswith("3.5.1"):
-        jquery_version = browser.execute(script)
-
-    browser.execute(load_fuzzy_lib())
+    logger.debug("inject cucu fuzzy find library to the browser")
+    jqCucu_script = "window.jqCucu = jQuery.noConflict(true);"
+    browser.execute(load_jquery_lib() + jqCucu_script + load_fuzzy_lib())
 
 
 class Direction(Enum):

--- a/src/cucu/steps/browser_steps.py
+++ b/src/cucu/steps/browser_steps.py
@@ -3,7 +3,7 @@ import os
 
 from selenium.webdriver.common.keys import Keys
 
-from cucu import config, fuzzy, logger, retry, run_steps, step
+from cucu import config, logger, retry, run_steps, step
 from cucu.browser.selenium import Selenium
 
 
@@ -37,7 +37,6 @@ def open_a_browser(ctx, url):
 
     logger.debug(f"navigating to url #{url}")
     ctx.browser.navigate(url)
-    fuzzy.init(ctx.browser)
 
 
 @step('I open a new browser at the url "{url}"')
@@ -46,7 +45,6 @@ def open_a_new_browser(ctx, url):
     ctx.browsers.append(ctx.browser)
     logger.debug(f"navigating to url #{url}")
     ctx.browser.navigate(url)
-    fuzzy.init(ctx.browser)
 
 
 @step("I execute in the current browser the following javascript")


### PR DESCRIPTION
In cases where a webpage redirects to another webpage, the context of the browser is cleared and the loaded javascript is lost. This causes `jQuery` or `jqCucu` not defined error.

We don't need to load the needed javascript code at the beginning of the new browser since it's loaded at each `fuzzy.find` call.

In this PR, the injection of the all the needed JS code is combined into one browser execution. This reduces the chance of half loaded code