### PR TITLE
Set URI values in homepage and repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.172.0
+- Add repository and homepage fields to solve an issue with pip/poetry failing to install this package.
+
 ## 0.171.0
 - Change - shorten image filenames for OS compatibiltiy
 - Add - enable install on python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.171.0"
+version = "0.172.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]


### PR DESCRIPTION
### What's the issue?
https://dominodatalab.slack.com/archives/C013UJQ6R7D/p1698763069859449

```
#0 0.752 Collecting cucu
#0 0.752   Cloning ssh://****@github.com/cerebrotech/cucu (to revision 0.170.0) to /tmp/pip-install-ao1cl4uc/cucu_403cd9c590f7466fb4872375b1ec41cf
#0 0.754   Running command git clone --filter=blob:none --quiet 'ssh://****@github.com/cerebrotech/cucu' /tmp/pip-install-ao1cl4uc/cucu_403cd9c590f7466fb4872375b1ec41cf
#0 1.407   Running command git checkout -q 0ee72f68e47b35eb83a3144ea95decc1eee5548d
#0 1.781   Resolved ssh://****@github.com/cerebrotech/cucu to commit 0ee72f68e47b35eb83a3144ea95decc1eee5548d
#0 1.786   Installing build dependencies: started
#0 3.904   Installing build dependencies: finished with status 'done'
#0 3.905   Getting requirements to build wheel: started
#0 3.998   Getting requirements to build wheel: finished with status 'done'
#0 3.999   Preparing metadata (pyproject.toml): started
#0 4.147   Preparing metadata (pyproject.toml): finished with status 'error'
#0 4.152   error: subprocess-exited-with-error
#0 4.152   
#0 4.152   × Preparing metadata (pyproject.toml) did not run successfully.
#0 4.152   │ exit code: 1
#0 4.152   ╰─> [17 lines of output]
#0 4.152       Traceback (most recent call last):
#0 4.152         File "/home/circleci/.pyenv/versions/3.11.2/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
#0 4.152           main()
#0 4.152         File "/home/circleci/.pyenv/versions/3.11.2/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
#0 4.152           json_out['return_val'] = hook(**hook_input['kwargs'])
#0 4.152                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#0 4.152         File "/home/circleci/.pyenv/versions/3.11.2/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
#0 4.152           return hook(metadata_directory, config_settings)
#0 4.152                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#0 4.152         File "/tmp/pip-build-env-rp5ex91u/overlay/lib/python3.11/site-packages/poetry/core/masonry/api.py", line 42, in prepare_metadata_for_build_wheel
#0 4.152           poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
#0 4.152                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#0 4.152         File "/tmp/pip-build-env-rp5ex91u/overlay/lib/python3.11/site-packages/poetry/core/factory.py", line 58, in create_poetry
#0 4.152           raise RuntimeError("The Poetry configuration is invalid:\n" + message)
#0 4.152       RuntimeError: The Poetry configuration is invalid:
#0 4.152         - data.homepage must be uri
```

### Replication
It's possible to replicate this: in a branch without the patch you can run (I prefixed everything with `pipenv run` on my local machine)
```
poetry build
pip install dist/cucu-0.171.0.tar.gz
```
and it will fail with the error above.
After applying the patches I no longer see those issues.