### PR TITLE
QE-14257 Fix jQuery loading in regex steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.177.0
+- Fix - text regex steps mess up the fuzzy find js code
+
 ## 0.176.0
 - Add - preliminary border injection behind feature flag
 

--- a/features/browser/text.feature
+++ b/features/browser/text.feature
@@ -1,5 +1,5 @@
 Feature: Text
-  As a developer I want to make sure the test writer can verify the visibilty
+  As a developer I want to make sure the test writer can verify the visibility
   of text on the page
 
   Scenario: User can see text within a simple label
@@ -83,3 +83,10 @@ Feature: Text
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/text.html"
      Then I match the regex "(?P<word>[^ ]*)\s*to Clipboard" on the current page and save the group "word" to the variable "WORD"
      Then I should see "{WORD}" is equal to "Copy"
+
+  Scenario: User can do regex text match and fuzzy find on the same page
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/text.html"
+     Then I should see the text "just some text in a label"
+      And I should see text matching the regex "just.*a.l[abcd]bel" on the current page
+      And I should see the text "just some text in a label"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.176.0"
+version = "0.177.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -143,7 +143,10 @@ def text_in_current_frame(browser: Browser) -> str:
     Args:
         browser (Browser): the browser session switched to the desired frame
     """
-    browser.execute(load_jquery_lib())
-    browser.execute("window.jqCucu = jQuery.noConflict(true);")
+    script = "return window.jqCucu && jqCucu.fn.jquery;"
+    jquery_version = browser.execute(script)
+    if not jquery_version:
+        browser.execute(load_jquery_lib())
+        browser.execute("window.jqCucu = jQuery.noConflict(true);")
     text = browser.execute('return jqCucu("body").children(":visible").text();')
     return text


### PR DESCRIPTION
regex steps load jQuery again and if it follows a fuzzy find step and then is followed by another fuzzy find step, the second fuzzy find step won't use the correct jQuery. This PR makes sure that if jQuery is already loaded, the regex steps won't reload it.

A functional test is created to reproduce the issue and verify the fix.