### PR TITLE
QE-14478 Only obfuscate certain places in json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.180.0
+- Change - only obfuscate certain parts in json output
+
+## 0.179.0
+- Fix - step that expects to not see a table
+
 ## 0.178.0
 - Add - error message to json and junit
 - Change - print expected and found tables on fail

--- a/data/features/with_secret/scenario_with_comments.feature
+++ b/data/features/with_secret/scenario_with_comments.feature
@@ -15,9 +15,14 @@ Feature: Feature with comments
           """
 
      * # Second comment about
+     # we shouldn't set a secret this way in production because the secret will end up
+     # in the source code. However, in test, this is a simple way to mimic a secret
      When I set the variable "MY_SECRET" to "buzz"
-      And I write "buzz" into the input "input type=text"
-     Then I should see the text "buzz"
+      And I write "{MY_SECRET}" into the input "input type=text"
+     Then I should see the text "{MY_SECRET}"
 
      * # Comment about {MY_SECRET}
      Then I echo "{MY_SECRET}"
+
+     * # Cause an intended exception with secrets
+     Then I click the button "{MY_SECRET}"

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -31,7 +31,7 @@ Feature: Report basics
       """
 
   Scenario: User can run a test and see extended output
-    Given I run the command "cucu run data/features/with_secret/scenario_with_comments.feature --results {CUCU_RESULTS_DIR}/browser-results --env CUCU_BROKEN_IMAGES_PAGE_CHECK=disabled" and expect exit code "0"
+    Given I run the command "cucu run data/features/with_secret/scenario_with_comments.feature --results {CUCU_RESULTS_DIR}/browser-results --env CUCU_BROKEN_IMAGES_PAGE_CHECK=disabled" and expect exit code "1"
       And I run the command "cucu report {CUCU_RESULTS_DIR}/browser-results --output {CUCU_RESULTS_DIR}/browser-report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/browser-report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/flat.html"
@@ -49,8 +49,12 @@ Feature: Report basics
       And I wait to see the text "# MY_SECRET="****""
 
         * # Can see image for step with secret in name
-     When I click the button "I should see the text "****""
-     Then I should see the image with the alt text "Then I should see the text "****""
+     When I click the button "I should see the text "\{MY_SECRET\}""
+     Then I should see the image with the alt text "Then I should see the text "\{MY_SECRET\}""
+
+        * # Cannot see secrets in the exception message
+     When I click the button "Then I click the button "\{MY_SECRET\}""
+     Then I should see the text "unable to find the button "****""
 
   @QE-6852
   Scenario: User can run a multi scenario test with web steps and generate report with a shareable url

--- a/features/cli/secrets.feature
+++ b/features/cli/secrets.feature
@@ -17,7 +17,7 @@ Feature: Secrets
           run_steps(
               context,
               \"\"\"
-          When I echo "super secret"
+          When I echo "\{MY_SECRET\}"
           \"\"\",
           )
       """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.179.0"
+version = "0.180.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/config.py
+++ b/src/cucu/config.py
@@ -156,7 +156,7 @@ class Config(dict):
 
         return references
 
-    def hide_secrets(self, text):
+    def hide_secrets(self, text: str | bytes):
         secret_keys = [x for x in self.get("CUCU_SECRETS", "").split(",") if x]
         secret_values = [self.get(x) for x in secret_keys if self.get(x)]
         secret_values = [x for x in secret_values if isinstance(x, str)]


### PR DESCRIPTION
We have a case where a secret is a number and cucu obfuscates the timestamp value that causes failure to generate cucu report.

The places where secrets may be leaked are in step variables, step outputs and error messages. Therefore, instead of search and replace the whole json stream, cucu should only look for these three places.