### PR TITLE
QE-14488 Redact only values in config yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.181.0
+- Change - only obfuscate values in config yaml file
+
 ## 0.180.0
 - Change - only obfuscate certain parts in json output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.180.0"
+version = "0.181.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]


### PR DESCRIPTION
If keys are redacted in yaml file, the yaml file will become invalid.