### PR TITLE
QE-14935 Improve clear_input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.187.0
+- Fix - clearing input sometimes causes the input to be not interactable
+
 ## 0.186.0
 - Fix - handle mht data response that is not of type dictionary
 

--- a/data/www/inputs.html
+++ b/data/www/inputs.html
@@ -5,6 +5,12 @@
     function update(value) {
         document.querySelector("#input").value = value + " was modified";
     }
+
+    function verify_enter(event) {
+        if (event.key == "Enter") {
+            document.querySelector("#input").value = "Enter was sent";
+        }
+    }
     </script>
   </head>
   <body>
@@ -27,6 +33,7 @@
     <p for="input-for">input with label for</p> <input onkeypress="update('input with label for');" id="input-for" type="text"></input><br/>
     <label>textarea with label</label>          <textarea onkeypress="update('textarea with label');"></textarea><br/>
     <p for="following-input">following input to a textarea</p><input onkeypress="update('following input to a textarea');" id="following-input" type="text"></input><br/>
+    <label>input accepting enter</label>.         <input onkeypress="verify_enter(event);" type="text"></input><br/>
 
     <label>input with @value set</label>        <input onkeypress="update('input with @value set');" value="foo"></input><br/>
 

--- a/features/browser/inputs.feature
+++ b/features/browser/inputs.feature
@@ -126,6 +126,14 @@ Feature: Inputs
      Then I should see "blup" in the input "input with label for"
       And I should see "input with label for was modified" in the input "last touched input"
 
+  Scenario: User can send an enter key after content
+    Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
+      And I should see no value in the input "input accepting enter"
+     When I write "beep" into the input "input accepting enter"
+      And I send the "enter" key to the input "input accepting enter"
+     Then I should see "beep" in the input "input accepting enter"
+      And I should see "Enter was sent" in the input "last touched input"
+
   @wait
   Scenario: User can wait to clear an input
     Given I set the variable "CUCU_STEP_WAIT_TIMEOUT_S" to "5"
@@ -168,7 +176,7 @@ Feature: Inputs
      Then I write "bar" into the input "input with @value set"
       And I should see "bar" in the input "input with @value set"
 
-  Scenario: User can write into a disabled input field
+  Scenario: User cannot write into a disabled input field
     Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
      Then I should see the input "disabled input" is disabled
       And I expect the following step to fail with "unable to write into the input, as it is disabled"
@@ -176,7 +184,7 @@ Feature: Inputs
       Then I write "foo" into the input "disabled input"
       """
 
-  Scenario: User can not clear a disabled input field
+  Scenario: User cannot clear a disabled input field
     Given I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
      Then I should see the input "disabled input" is disabled
       And I expect the following step to fail with "unable to clear the input, as it is disabled"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1245,7 +1245,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1253,16 +1252,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1279,7 +1270,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1287,7 +1277,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1561,13 +1550,13 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "stevedore"
-version = "5.1.0"
+version = "5.2.0"
 description = "Manage dynamic plugins for Python applications"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "stevedore-5.1.0-py3-none-any.whl", hash = "sha256:8cc040628f3cea5d7128f2e76cf486b2251a4e543c7b938f58d9a377f6694a2d"},
-    {file = "stevedore-5.1.0.tar.gz", hash = "sha256:a54534acf9b89bc7ed264807013b505bf07f74dbe4bcfa37d32bd063870b087c"},
+    {file = "stevedore-5.2.0-py3-none-any.whl", hash = "sha256:1c15d95766ca0569cad14cb6272d4d31dae66b011a929d7c18219c176ea1b5c9"},
+    {file = "stevedore-5.2.0.tar.gz", hash = "sha256:46b93ca40e1114cea93d738a6c1e365396981bb6bb78c27045b7587c9473544d"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.186.0"
+version = "0.187.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/steps/input_steps.py
+++ b/src/cucu/steps/input_steps.py
@@ -66,8 +66,6 @@ def clear_input(input_):
     """
     internal method used to clear inputs and make sure they clear correctly
     """
-    input_.clear()
-
     # Keys.CONTROL works on the Selenium grid (when running in CI)
     #  - it stopped working on laptop after the upgrade in antd version (Feb 2023)
     # Keys.COMMAND works on laptop, but not on Selenium grid,
@@ -79,7 +77,7 @@ def clear_input(input_):
     input_.send_keys(Keys.BACKSPACE)
 
 
-def find_n_write(ctx, name, value, index=0):
+def find_n_write(ctx, name, value, index=0, clear_existing=True):
     """
     find the input with the name provided and write the value provided into it.
 
@@ -87,6 +85,7 @@ def find_n_write(ctx, name, value, index=0):
       ctx(object): behave context object used to share data between steps
       name(str):   name that identifies the desired input on screen
       index(str):  the index of the input if there are a few with the same name.
+      clear_existing(bool): if clearing the existing content before writing
 
     raises:
         an error if the desired input is not found
@@ -98,7 +97,9 @@ def find_n_write(ctx, name, value, index=0):
     if base_steps.is_disabled(input_):
         raise RuntimeError("unable to write into the input, as it is disabled")
 
-    clear_input(input_)
+    if clear_existing:
+        clear_input(input_)
+
     if len(value) > 512:
         #
         # to avoid various bugs with writing large chunks of text into
@@ -215,7 +216,7 @@ def wait_up_to_write_multi_lines_into_input(ctx, seconds, name):
 
 @step('I send the "{key}" key to the input "{name}"')
 def send_keys_to_input(ctx, key, name):
-    find_n_write(ctx, name, Keys.__dict__[key.upper()])
+    find_n_write(ctx, name, Keys.__dict__[key.upper()], clear_existing=False)
 
 
 @step('I clear the input "{name}"')


### PR DESCRIPTION
`input_.clear()` in `clear_input()` sometimes causes an element not interactable. Since the function has another method of clearing the input, `input_.clear()` is not needed.

Surprisingly, removing the call uncovers another bug in cucu, which is that sending a key to the input accidentally clears the existing content. This is not desired since the most use case for that step is after writing to the input, we then send an enter key to trigger an action. This PR fixes the behavior.

The change is also tested in E2E tests