### PR TITLE
QE-15026 Fix how element size is calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.188.0
+- Fix - how element size is gotten in fuzzy find
+
 ## 0.187.0
 - Fix - clearing input sometimes causes the input to be not interactable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.187.0"
+version = "0.188.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/fuzzy/fuzzy.js
+++ b/src/cucu/fuzzy/fuzzy.js
@@ -20,7 +20,7 @@
                 return (elem.textContent || elem.innerText || jqCucu(elem).text() || '').trim() === match[3].trim();
             },
             vis: function (elem) {
-                return !(jqCucu(elem).is(":hidden") || jqCucu(elem).width() == 0 || jqCucu(elem).height == 0 || jqCucu(elem).parents(":hidden").length);
+                return !(jqCucu(elem).is(":hidden") || jqCucu(elem).css("width") == "0px" || jqCucu(elem).css("height") == "0px" || jqCucu(elem).parents(":hidden").length);
             }
         }
     );


### PR DESCRIPTION
In some cases, the content size of the element can be 0 although the element itself is not 0 in width or height. This PR changed the way to use the css attributes of the two to decide the element size.