### PR TITLE
QE-15340 QE-15386 Fix report of long feature/scenario names and replace & in file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.194.0
+- Fix - HTML report is generated into a wrong folder
+- Change - `&` is replaced in file name
+- Change - shortened feature name and scenario name are recorded in JUnit
+
+## 0.194.0
 - Fix - Ignore exceptions while key in desired dynamic dropdown value
 
 ## 0.193.0

--- a/data/features/feature_with_long_names.feature
+++ b/data/features/feature_with_long_names.feature
@@ -1,0 +1,5 @@
+Feature: Feature with an absolutely unnecessarily, ridiculously, comically, I don't know what they're thinking, long name
+
+  Scenario: Scenario with an absolutely unnecessarily, ridiculously, comically, I don't know what they're thinking, long name
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/buttons.html"

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -144,26 +144,26 @@ Feature: Run outputs
      Then I should see a file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/Feature with mixed results.xml"
       And I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/Feature with mixed results.xml" matches the following:
       """
-      <testsuite name="Feature with mixed results" tests="7" errors="0" failures="3" skipped="1" timestamp=".*" tags="mixed">
-       <testcase classname="Feature with mixed results" name="Scenario that passes" status="passed" time=".*">
+      <testsuite name="Feature with mixed results" shortname="Feature with mixed results" tests="7" errors="0" failures="3" skipped="1" timestamp=".*" tags="mixed">
+       <testcase classname="Feature with mixed results" name="Scenario that passes" shortname="Scenario that passes" status="passed" time=".*">
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario that fails" status="failed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario that fails" shortname="Scenario that fails" status="failed" time=".*">
         <failure>
         [\s\S]*
         </failure>
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario and after-hook both fail" status="failed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario and after-hook both fail" shortname="Scenario and after-hook both fail" status="failed" time=".*">
         <failure>
         [\s\S]*
         </failure>
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario with after-hook error" status="passed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario with after-hook error" shortname="Scenario with after-hook error" status="passed" time=".*">
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario that also passes" status="passed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario that also passes" shortname="Scenario that also passes" status="passed" time=".*">
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario that has an undefined step" status="failed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario that has an undefined step" shortname="Scenario that has an undefined step" status="failed" time=".*">
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario that is skipped" status="skipped" time=".*" tags="disabled">
+       <testcase classname="Feature with mixed results" name="Scenario that is skipped" shortname="Scenario that is skipped" status="skipped" time=".*" tags="disabled">
         <skipped>
         </skipped>
        </testcase>

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -144,26 +144,26 @@ Feature: Run outputs
      Then I should see a file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/Feature with mixed results.xml"
       And I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/Feature with mixed results.xml" matches the following:
       """
-      <testsuite name="Feature with mixed results" shortname="Feature with mixed results" tests="7" errors="0" failures="3" skipped="1" timestamp=".*" tags="mixed">
-       <testcase classname="Feature with mixed results" name="Scenario that passes" shortname="Scenario that passes" status="passed" time=".*">
+      <testsuite name="Feature with mixed results" foldername="Feature with mixed results" tests="7" errors="0" failures="3" skipped="1" timestamp=".*" tags="mixed">
+       <testcase classname="Feature with mixed results" name="Scenario that passes" foldername="Scenario that passes" status="passed" time=".*">
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario that fails" shortname="Scenario that fails" status="failed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario that fails" foldername="Scenario that fails" status="failed" time=".*">
         <failure>
         [\s\S]*
         </failure>
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario and after-hook both fail" shortname="Scenario and after-hook both fail" status="failed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario and after-hook both fail" foldername="Scenario and after-hook both fail" status="failed" time=".*">
         <failure>
         [\s\S]*
         </failure>
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario with after-hook error" shortname="Scenario with after-hook error" status="passed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario with after-hook error" foldername="Scenario with after-hook error" status="passed" time=".*">
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario that also passes" shortname="Scenario that also passes" status="passed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario that also passes" foldername="Scenario that also passes" status="passed" time=".*">
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario that has an undefined step" shortname="Scenario that has an undefined step" status="failed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario that has an undefined step" foldername="Scenario that has an undefined step" status="failed" time=".*">
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario that is skipped" shortname="Scenario that is skipped" status="skipped" time=".*" tags="disabled">
+       <testcase classname="Feature with mixed results" name="Scenario that is skipped" foldername="Scenario that is skipped" status="skipped" time=".*" tags="disabled">
         <skipped>
         </skipped>
        </testcase>

--- a/features/cli/run_with_report.feature
+++ b/features/cli/run_with_report.feature
@@ -18,3 +18,12 @@ Feature: Run with report
      Then I should see the link "Feature with failing scenario"
      When I click the link "Feature with failing scenario"
      Then I should see the link "Just a scenario that fails"
+
+  Scenario: User can generate a correct report with long feature name and scenario name
+    Given I run the command "cucu run data/features/feature_with_long_names.feature --results {CUCU_RESULTS_DIR}/run_with_report_results --generate-report --report {CUCU_RESULTS_DIR}/run_with_report_report" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      And I start a webserver at directory "{CUCU_RESULTS_DIR}/run_with_report_report/" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
+     Then I should see the link "Feature with an absolutely unnecessarily, ridiculously, comically, I don't know what they're thinking, long name"
+     When I click the link "Feature with an absolutely unnecessarily, ridiculously, comically, I don't know what they're thinking, long name"
+     Then I should see the link "Scenario with an absolutely unnecessarily, ridiculously, comically, I don't know what they're thinking, long name"
+      And I click the link "Scenario with an absolutely unnecessarily, ridiculously, comically, I don't know what they're thinking, long name"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.194.0"
+version = "0.195.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/formatter/junit.py
+++ b/src/cucu/formatter/junit.py
@@ -39,7 +39,7 @@ class CucuJUnitFormatter(Formatter):
         date_now = datetime.now()
         self.feature_results = {
             "name": escape(feature.name),
-            "shortname": escape(ellipsize_filename(feature.name)),
+            "foldername": escape(ellipsize_filename(feature.name)),
             "tests": 0,
             "errors": 0,
             "failures": 0,
@@ -117,7 +117,7 @@ class CucuJUnitFormatter(Formatter):
             "failure": None,
             "skipped": None,
         }
-        self.current_scenario_results["shortname"] = escape(
+        self.current_scenario_results["foldername"] = escape(
             ellipsize_filename(scenario.name)
         )
         if scenario.tags:
@@ -169,7 +169,7 @@ class CucuJUnitFormatter(Formatter):
         given a feature results dictionary that looks like so:
             {
                 "name": "name of the feature",
-                "shortname": "",
+                "foldername": "",
                 "tests": 0,
                 "errors": 0,
                 "failures": 0,
@@ -177,7 +177,7 @@ class CucuJUnitFormatter(Formatter):
                 "timestamp": "",
                 "scenarios": {
                     "scenario name": {
-                        "shortname": "",
+                        "foldername": "",
                         "tags": "DOM-3435, testrail(3366,45891)",
                         "status": "passed/failed/skipped",
                         "time": "0.0000":
@@ -196,7 +196,7 @@ class CucuJUnitFormatter(Formatter):
                 ordered = [
                     "classname",
                     "name",
-                    "shortname",
+                    "foldername",
                     "tests",
                     "errors",
                     "failures",
@@ -214,7 +214,7 @@ class CucuJUnitFormatter(Formatter):
         soup = bs4.BeautifulSoup()
         testsuite = bs4.Tag(name="testsuite")
         testsuite["name"] = results["name"]
-        testsuite["shortname"] = results["shortname"]
+        testsuite["foldername"] = results["foldername"]
         testsuite["timestamp"] = results["timestamp"]
 
         junit_dir = CONFIG["CUCU_JUNIT_DIR"]
@@ -264,7 +264,7 @@ class CucuJUnitFormatter(Formatter):
             testcase = bs4.Tag(name="testcase")
             testcase["classname"] = results["name"]
             testcase["name"] = scenario_name
-            testcase["shortname"] = scenario["shortname"]
+            testcase["foldername"] = scenario["foldername"]
             if "tags" in scenario:
                 testcase["tags"] = scenario["tags"]
             testcase["status"] = scenario["status"]

--- a/src/cucu/formatter/junit.py
+++ b/src/cucu/formatter/junit.py
@@ -117,7 +117,9 @@ class CucuJUnitFormatter(Formatter):
             "failure": None,
             "skipped": None,
         }
-        self.current_scenario_results["shortname"] = escape(ellipsize_filename(scenario.name))
+        self.current_scenario_results["shortname"] = escape(
+            ellipsize_filename(scenario.name)
+        )
         if scenario.tags:
             self.current_scenario_results["tags"] = ", ".join(scenario.tags)
 

--- a/src/cucu/formatter/junit.py
+++ b/src/cucu/formatter/junit.py
@@ -11,6 +11,7 @@ from bs4.formatter import XMLFormatter
 from tenacity import RetryError
 
 from cucu.config import CONFIG
+from cucu.utils import ellipsize_filename
 
 
 class CucuJUnitFormatter(Formatter):
@@ -38,6 +39,7 @@ class CucuJUnitFormatter(Formatter):
         date_now = datetime.now()
         self.feature_results = {
             "name": escape(feature.name),
+            "shortname": escape(ellipsize_filename(feature.name)),
             "tests": 0,
             "errors": 0,
             "failures": 0,
@@ -115,6 +117,7 @@ class CucuJUnitFormatter(Formatter):
             "failure": None,
             "skipped": None,
         }
+        self.current_scenario_results["shortname"] = escape(ellipsize_filename(scenario.name))
         if scenario.tags:
             self.current_scenario_results["tags"] = ", ".join(scenario.tags)
 
@@ -123,7 +126,7 @@ class CucuJUnitFormatter(Formatter):
             scenario_name
         ] = self.current_scenario_results
 
-        # we write out every new scenario into the JUnit results output which
+        # we write out every new scenario into the JUnit results output
         # which allows us to have a valid JUnit XML results file per feature
         # file currently running even if the process crashes or is killed so we
         # can still generate valid reports from every run.
@@ -164,6 +167,7 @@ class CucuJUnitFormatter(Formatter):
         given a feature results dictionary that looks like so:
             {
                 "name": "name of the feature",
+                "shortname": "",
                 "tests": 0,
                 "errors": 0,
                 "failures": 0,
@@ -171,6 +175,7 @@ class CucuJUnitFormatter(Formatter):
                 "timestamp": "",
                 "scenarios": {
                     "scenario name": {
+                        "shortname": "",
                         "tags": "DOM-3435, testrail(3366,45891)",
                         "status": "passed/failed/skipped",
                         "time": "0.0000":
@@ -189,6 +194,7 @@ class CucuJUnitFormatter(Formatter):
                 ordered = [
                     "classname",
                     "name",
+                    "shortname",
                     "tests",
                     "errors",
                     "failures",
@@ -206,6 +212,7 @@ class CucuJUnitFormatter(Formatter):
         soup = bs4.BeautifulSoup()
         testsuite = bs4.Tag(name="testsuite")
         testsuite["name"] = results["name"]
+        testsuite["shortname"] = results["shortname"]
         testsuite["timestamp"] = results["timestamp"]
 
         junit_dir = CONFIG["CUCU_JUNIT_DIR"]
@@ -255,6 +262,7 @@ class CucuJUnitFormatter(Formatter):
             testcase = bs4.Tag(name="testcase")
             testcase["classname"] = results["name"]
             testcase["name"] = scenario_name
+            testcase["shortname"] = scenario["shortname"]
             if "tags" in scenario:
                 testcase["tags"] = scenario["tags"]
             testcase["status"] = scenario["status"]

--- a/src/cucu/reporter/html.py
+++ b/src/cucu/reporter/html.py
@@ -100,6 +100,7 @@ def generate(results, basepath, only_failures=False):
     CONFIG.snapshot()
     reported_features = []
     for feature in features:
+        feature["folder_name"] = ellipsize_filename(feature["name"])
         if show_status:
             print("F", end="", flush=True)
         scenarios = []
@@ -123,11 +124,9 @@ def generate(results, basepath, only_failures=False):
 
         if feature["status"] not in ["skipped", "untested"]:
             # copy each feature directories contents over to the report directory
-            src_feature_filepath = os.path.join(
-                results, ellipsize_filename(feature["name"])
-            )
+            src_feature_filepath = os.path.join(results, feature["folder_name"])
             dst_feature_filepath = os.path.join(
-                basepath, ellipsize_filename(feature["name"])
+                basepath, feature["folder_name"]
             )
             shutil.copytree(
                 src_feature_filepath, dst_feature_filepath, dirs_exist_ok=True
@@ -136,10 +135,11 @@ def generate(results, basepath, only_failures=False):
         for scenario in scenarios:
             CONFIG.restore()
 
+            scenario["folder_name"] = ellipsize_filename(scenario["name"])
             scenario_filepath = os.path.join(
                 basepath,
-                ellipsize_filename(feature["name"]),
-                ellipsize_filename(scenario["name"]),
+                feature["folder_name"],
+                scenario["folder_name"],
             )
 
             scenario_configpath = os.path.join(
@@ -399,7 +399,7 @@ def generate(results, basepath, only_failures=False):
     feature_template = templates.get_template("feature.html")
 
     for feature in reported_features:
-        feature_basepath = os.path.join(basepath, feature["name"])
+        feature_basepath = os.path.join(basepath, feature["folder_name"])
         os.makedirs(feature_basepath, exist_ok=True)
 
         scenarios = []
@@ -424,7 +424,9 @@ def generate(results, basepath, only_failures=False):
 
         for scenario in scenarios:
             steps = scenario["steps"]
-            scenario_basepath = os.path.join(feature_basepath, scenario["name"])
+            scenario_basepath = os.path.join(
+                feature_basepath, scenario["folder_name"]
+            )
             os.makedirs(scenario_basepath, exist_ok=True)
 
             scenario_output_filepath = os.path.join(

--- a/src/cucu/reporter/templates/feature.html
+++ b/src/cucu/reporter/templates/feature.html
@@ -55,7 +55,7 @@
                 {% endif %}
                 </td>
                 <td>
-                    <a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><span style="display: inline; color: grey">{{ escape(scenario['name']) }}</span></a><br/>
+                    <a href="{{ urlencode(escape(feature['folder_name'])) }}/{{ urlencode(escape(scenario['folder_name'])) }}/index.html"><span style="display: inline; color: grey">{{ escape(scenario['name']) }}</span></a><br/>
                     <span style="display: inline; color: darkslateblue">{{ scenario['tags'] }}</span>
                 </td>
                 <td class="text-center">{{ scenario['total_steps'] }}</td>

--- a/src/cucu/reporter/templates/flat.html
+++ b/src/cucu/reporter/templates/flat.html
@@ -31,7 +31,7 @@
                 {% if scenario['keyword'] != 'Background' %}
                 <tr>
                     <td class="text-center">{{ scenario['started_at'] }}</td>
-                    <td><a href="{{ urlencode(escape(feature['folder_name'])) }}.html"><span>{{ escape(feature['name']) }}</span></a><br>{{ feature['tags'] }}</td>
+                    <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><span>{{ escape(feature['name']) }}</span></a><br>{{ feature['tags'] }}</td>
                     <td><a href="{{ urlencode(escape(feature['folder_name'])) }}/{{ urlencode(escape(scenario['folder_name'])) }}/index.html"><span>{{ escape(scenario['name']) }}</span></a><br>{{ scenario['tags'] }}</td>
                     <td class="text-center">{{ scenario['total_steps'] }}</td>
                     <td class="text-center"><span class="status-{{ scenario['status'] }}">{{ scenario['status'] }}</span></td>

--- a/src/cucu/reporter/templates/flat.html
+++ b/src/cucu/reporter/templates/flat.html
@@ -31,8 +31,8 @@
                 {% if scenario['keyword'] != 'Background' %}
                 <tr>
                     <td class="text-center">{{ scenario['started_at'] }}</td>
-                    <td><a href="{{ urlencode(escape(feature['name'])) }}.html"><span>{{ escape(feature['name']) }}</span></a><br>{{ feature['tags'] }}</td>
-                    <td><a href="{{ urlencode(escape(feature['name'])) }}/{{ urlencode(escape(scenario['name'])) }}/index.html"><span>{{ escape(scenario['name']) }}</span></a><br>{{ scenario['tags'] }}</td>
+                    <td><a href="{{ urlencode(escape(feature['folder_name'])) }}.html"><span>{{ escape(feature['name']) }}</span></a><br>{{ feature['tags'] }}</td>
+                    <td><a href="{{ urlencode(escape(feature['folder_name'])) }}/{{ urlencode(escape(scenario['folder_name'])) }}/index.html"><span>{{ escape(scenario['name']) }}</span></a><br>{{ scenario['tags'] }}</td>
                     <td class="text-center">{{ scenario['total_steps'] }}</td>
                     <td class="text-center"><span class="status-{{ scenario['status'] }}">{{ scenario['status'] }}</span></td>
                     <td class="text-center">{{ scenario['duration'] }}</td>

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -180,6 +180,7 @@ def normalize_filename(raw_filename):
         .replace("{", "")
         .replace("}", "")
         .replace("#", "")
+        .replace("&", "")
     )
     return normalized_filename
 


### PR DESCRIPTION
There is a bug introduced in https://github.com/cerebrotech/cucu/pull/442 such that if the feature/scenario names are long, the report is not generated in the right folder.

This PR fixes that bug and created a test to verify it. It also save the shortened name in the Junit report such that it can be used by `domino-testrail` to generate the link of the html report on TestRail

In addition, `&` is replaced in the file names