### PR TITLE
QE-15477 do not replace scenario error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.194.0
+## 0.196.0
+- Fix - after scenario hook error message unintentionally replaces scenario error message
+
+## 0.195.0
 - Fix - HTML report is generated into a wrong folder
 - Change - `&` is replaced in file name
 - Change - shortened feature name and scenario name are recorded in JUnit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cucu"
-version = "0.195.0"
+version = "0.196.0"
 license = "MIT"
 description = "Easy BDD web testing"
 authors = ["Domino Data Lab <open-source@dominodatalab.com>"]

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -137,7 +137,6 @@ def run_after_scenario_hook(ctx, scenario, hook):
             f"HOOK-ERROR in {hook.__name__}: {e.__class__.__name__}: {e}\n"
         )
         error_message += traceback.format_exc()
-        scenario.error_message = error_message
         logger.error(error_message)
 
 


### PR DESCRIPTION
Currently, when a scenario fails and the after scenario hook also fails, the after scenario hook error message overwrites the scenario failure error message. It makes debugging the actual failure difficult.

After this PR, the after scenario hook error message will be in the log file but not in the secnario error message