### PR TITLE
DOM-62795 Capture debug logs after and before failed iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.4
+- Change - for retry steps, also log before and after call messages
+
 ## 1.0.3
 - Add - functional test for drag and drop file functionality
 

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -204,7 +204,7 @@ Feature: Report basics
   @runtime-timeout
   Scenario: User can run with a runtime timeout and still produce a valid report
     Given I run the command "cucu run data/features/slow_features --runtime-timeout 9 --results {CUCU_RESULTS_DIR}/runtime_timeout_reporting_results" and expect exit code "1"
-     Then I should see the previous step took less than "13" seconds
+     Then I should see the previous step took less than "14" seconds
      When I run the command "cucu report {CUCU_RESULTS_DIR}/runtime_timeout_reporting_results --output {CUCU_RESULTS_DIR}/runtime_timeout_reporting_report" and expect exit code "0"
       And I start a webserver at directory "{CUCU_RESULTS_DIR}/runtime_timeout_reporting_report/" and save the port to the variable "PORT"
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.0.3"
+version = "1.0.4"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }

--- a/src/cucu/steps/file_input_steps.py
+++ b/src/cucu/steps/file_input_steps.py
@@ -68,6 +68,7 @@ JS_DROP_FILE = """
     return input;
 """
 
+
 def drag_and_drop_file(ctx, name, filepath):
     drop_target = fuzzy.find(ctx.browser, name, ["*"])
     drop_target_html = drop_target.get_attribute("outerHTML")

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -11,6 +11,8 @@ import shutil
 import humanize
 from tabulate import DataRow, TableFormat, tabulate
 from tenacity import (
+    before_log,
+    after_log,
     before_sleep_log,
     retry_if_not_exception_type,
     stop_after_delay,
@@ -119,6 +121,8 @@ def retry(func, wait_up_to_s=None, retry_after_s=None):
         stop=stop_after_delay(wait_up_to_s),
         wait=wait_fixed(retry_after_s),
         retry=retry_if_not_exception_type(StopRetryException),
+        before=before_log(logger, logging.DEBUG),
+        after=after_log(logger, logging.DEBUG),
         before_sleep=before_sleep_log(logger, logging.DEBUG),
     )
     def new_decorator(*args, **kwargs):

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -11,8 +11,8 @@ import shutil
 import humanize
 from tabulate import DataRow, TableFormat, tabulate
 from tenacity import (
-    before_log,
     after_log,
+    before_log,
     before_sleep_log,
     retry_if_not_exception_type,
     stop_after_delay,

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
In cucu debug logs, we are not capturing the before and after action logs for the tenacity retry calls. 

Issue Number: https://dominodatalab.atlassian.net/browse/

## What is the new behavior?
Start capturing these logs to help us debug issues seen during retry steps.

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Example log output with changes for one wait step:
```
     Then I wait up to "{ENVIRONMENT_REVISION_BUILD_TIMEOUT_S}" seconds for the environment revision in "1st" row to have status "Build Succeeded" on the environments page
2024-10-22 16:19:29,749 DEBUG Starting call to 'cucu.utils.retry.<locals>.new_decorator', this is the 1st time calling it.
2024-10-22 16:19:29,771 DEBUG Finished call to 'cucu.utils.retry.<locals>.new_decorator' after 0.022(s), this was the 1st time calling it.
2024-10-22 16:19:29,771 DEBUG Retrying cucu.utils.retry.<locals>.new_decorator in 0.5 seconds as it raised RuntimeError: Expected environment revision in row 1 from top to have status "Build Succeeded", but it had status "Build Building"..
2024-10-22 16:19:30,276 DEBUG Starting call to 'cucu.utils.retry.<locals>.new_decorator', this is the 2nd time calling it.
2024-10-22 16:19:30,296 DEBUG Finished call to 'cucu.utils.retry.<locals>.new_decorator' after 0.547(s), this was the 2nd time calling it.
2024-10-22 16:19:30,296 DEBUG Retrying cucu.utils.retry.<locals>.new_decorator in 0.5 seconds as it raised RuntimeError: Expected environment revision in row 1 from top to have status "Build Succeeded", but it had status "Build Building"..
2024-10-22 16:19:30,801 DEBUG Starting call to 'cucu.utils.retry.<locals>.new_decorator', this is the 3rd time calling it.
2024-10-22 16:19:30,822 DEBUG Finished call to 'cucu.utils.retry.<locals>.new_decorator' after 1.073(s), this was the 3rd time calling it.
2024-10-22 16:19:30,822 DEBUG Retrying cucu.utils.retry.<locals>.new_decorator in 0.5 seconds as it raised RuntimeError: Expected environment revision in row 1 from top to have status "Build Succeeded", but it had status "Build Building"..
2024-10-22 16:19:31,326 DEBUG Starting call to 'cucu.utils.retry.<locals>.new_decorator', this is the 4th time calling it.
2024-10-22 16:19:31,345 DEBUG Finished call to 'cucu.utils.retry.<locals>.new_decorator' after 1.596(s), this was the 4th time calling it.
2024-10-22 16:19:31,345 DEBUG Retrying cucu.utils.retry.<locals>.new_decorator in 0.5 seconds as it raised RuntimeError: Expected environment revision in row 1 from top to have status "Build Succeeded", but it had status "Build Building"..
2024-10-22 16:19:31,847 DEBUG Starting call to 'cucu.utils.retry.<locals>.new_decorator', this is the 5th time calling it.
2024-10-22 16:19:31,868 DEBUG Finished call to 'cucu.utils.retry.<locals>.new_decorator' after 2.120(s), this was the 5th time calling it.
2024-10-22 16:19:31,869 DEBUG Retrying cucu.utils.retry.<locals>.new_decorator in 0.5 seconds as it raised RuntimeError: Expected environment revision in row 1 from top to have status "Build Succeeded", but it had status "Build Building"..
2024-10-22 16:19:32,373 DEBUG Starting call to 'cucu.utils.retry.<locals>.new_decorator', this is the 6th time calling it.
2024-10-22 16:19:32,392 DEBUG Finished call to 'cucu.utils.retry.<locals>.new_decorator' after 2.644(s), this was the 6th time calling it.
2024-10-22 16:19:32,393 DEBUG Retrying cucu.utils.retry.<locals>.new_decorator in 0.5 seconds as it raised RuntimeError: Expected environment revision in row 1 from top to have status "Build Succeeded", but it had status "Build Building"..
2024-10-22 16:19:32,895 DEBUG Starting call to 'cucu.utils.retry.<locals>.new_decorator', this is the 7th time calling it.
2024-10-22 16:19:32,915 DEBUG Finished call to 'cucu.utils.retry.<locals>.new_decorator' after 3.166(s), this was the 7th time calling it.
2024-10-22 16:19:32,915 DEBUG Retrying cucu.utils.retry.<locals>.new_decorator in 0.5 seconds as it raised RuntimeError: Expected environment revision in row 1 from top to have status "Build Succeeded", but it had status "Build Building"..
2024-10-22 16:19:33,418 DEBUG Starting call to 'cucu.utils.retry.<locals>.new_decorator', this is the 8th time calling it.
     Then I wait up to "{ENVIRONMENT_REVISION_BUILD_TIMEOUT_S}" seconds for the environment revision in "1st" row to have status "Build Succeeded" on the environments page                                                                            # started at 2024-10-22T16:19:29.748 took 3.689s
     # ENVIRONMENT_REVISION_BUILD_TIMEOUT_S="600"
```
