### PR TITLE
QE-17098---cucu---bump-pypi-publish-to-v1.1.0

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -28,4 +28,4 @@ jobs:
         run: |
           uv build
       - name: publish to pypi.org
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -30,6 +30,6 @@ jobs:
         run: |
           uv build
       - name: publish to test.pypi.org
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.8
+- Chore - bump pypi publishing GH action version
+
 ## 1.0.7
 - Fix - stablize CI runs (increase workers, add envvar tweaks)
 - Fix - parse --workers correctly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.0.7"
+version = "1.0.8"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [x] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://dominodatalab.atlassian.net/browse/QE-17098

## What is the new behavior?

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Turns out we've been doing this already, so this PR is just a bump in the GH action
- tested with GH action from this branch and releasing main https://github.com/dominodatalab/cucu/actions/runs/13124598797
- shows up on test.pypi.org https://test.pypi.org/project/cucu/#cucu-1.0.7.tar.gz
<img width="650" alt="image" src="https://github.com/user-attachments/assets/0501de7f-cf33-453c-b155-5cad6b77075a" />

