### PR TITLE
QE-17291 update for selenium 4.28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         environment:
           # Starting with python 3.12 coverage could be 2x slower so use experimental COVERAGE_CORE=sysmon
           COVERAGE_CORE: sysmon
-      - image: selenium/standalone-<<parameters.browser>>:126.0
+      - image: selenium/standalone-<<parameters.browser>>:129.0
         environment:
           SE_ENABLE_TRACING: false
           SE_NODE_MAX_SESSIONS: 12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         environment:
           # Starting with python 3.12 coverage could be 2x slower so use experimental COVERAGE_CORE=sysmon
           COVERAGE_CORE: sysmon
-      - image: selenium/standalone-<<parameters.browser>>:128.0
+      - image: selenium/standalone-<<parameters.browser>>:127.0
         environment:
           SE_ENABLE_TRACING: false
           SE_NODE_MAX_SESSIONS: 12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         environment:
           # Starting with python 3.12 coverage could be 2x slower so use experimental COVERAGE_CORE=sysmon
           COVERAGE_CORE: sysmon
-      - image: selenium/standalone-<<parameters.browser>>:132.0
+      - image: selenium/standalone-<<parameters.browser>>:126.0
         environment:
           SE_ENABLE_TRACING: false
           SE_NODE_MAX_SESSIONS: 12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         environment:
           # Starting with python 3.12 coverage could be 2x slower so use experimental COVERAGE_CORE=sysmon
           COVERAGE_CORE: sysmon
-      - image: selenium/standalone-<<parameters.browser>>:129.0
+      - image: selenium/standalone-<<parameters.browser>>:128.0
         environment:
           SE_ENABLE_TRACING: false
           SE_NODE_MAX_SESSIONS: 12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         environment:
           # Starting with python 3.12 coverage could be 2x slower so use experimental COVERAGE_CORE=sysmon
           COVERAGE_CORE: sysmon
-      - image: selenium/standalone-<<parameters.browser>>:125.0
+      - image: selenium/standalone-<<parameters.browser>>:132.0
         environment:
           SE_ENABLE_TRACING: false
           SE_NODE_MAX_SESSIONS: 12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         environment:
           # Starting with python 3.12 coverage could be 2x slower so use experimental COVERAGE_CORE=sysmon
           COVERAGE_CORE: sysmon
-      - image: selenium/standalone-<<parameters.browser>>:127.0
+      - image: selenium/standalone-<<parameters.browser>>:126.0
         environment:
           SE_ENABLE_TRACING: false
           SE_NODE_MAX_SESSIONS: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.9
+- Chore - update for selenium 4.28
+
 ## 1.0.8
 - Chore - bump pypi publishing GH action version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 
 ## 1.0.9
 - Chore - update for selenium 4.28
+- Chore - update CI with selenium docker images to 126
 
 ## 1.0.8
 - Chore - bump pypi publishing GH action version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "pygls~=1.3.1",
     "pyyaml~=6.0.1",
     "requests>=2.31.0,<3.0.0",
-    "selenium~=4.25",
+    "selenium~=4.28",
     "tabulate~=0.9.0",
     "tenacity~=9.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "pygls~=1.3.1",
     "pyyaml~=6.0.1",
     "requests>=2.31.0,<3.0.0",
-    "selenium~=4.15",
+    "selenium~=4.25",
     "tabulate~=0.9.0",
     "tenacity~=9.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.0.8"
+version = "1.0.9"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -56,6 +56,7 @@ class Selenium(Browser):
 
         timeout = float(config.CONFIG["CUCU_SELENIUM_DEFAULT_TIMEOUT_S"])
         os.environ["GLOBAL_DEFAULT_TIMEOUT"] = str(timeout)
+        logger.debug(f"GLOBAL_DEFAULT_TIMEOUT: {timeout}")
 
         height = config.CONFIG["CUCU_BROWSER_WINDOW_HEIGHT"]
         width = config.CONFIG["CUCU_BROWSER_WINDOW_WIDTH"]
@@ -293,7 +294,7 @@ class Selenium(Browser):
 
         mht_data = None
         if self.driver._is_remote:
-            cdp_url = f"{self.driver.command_executor._url}/session/{self.driver.session_id}/chromium/send_command_and_get_result"
+            cdp_url = f"{self.driver.command_executor._client_config.remote_server_addr}/session/{self.driver.session_id}/chromium/send_command_and_get_result"
             cdp_request_body = '{"cmd": "Page.captureSnapshot", "params": {}}'
             cdp_response = self.driver.command_executor._request(
                 "POST", cdp_url, cdp_request_body

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import chromedriver_autoinstaller
 import geckodriver_autoinstaller
@@ -8,7 +9,6 @@ from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.common.by import By
 from selenium.webdriver.edge.options import Options as EdgeOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from selenium.webdriver.remote.remote_connection import RemoteConnection
 
 from cucu import config, edgedriver_autoinstaller, logger
 from cucu.browser.core import Browser
@@ -55,7 +55,7 @@ class Selenium(Browser):
             init()
 
         timeout = float(config.CONFIG["CUCU_SELENIUM_DEFAULT_TIMEOUT_S"])
-        RemoteConnection.set_timeout(timeout)
+        os.environ["GLOBAL_DEFAULT_TIMEOUT"] = str(timeout)
 
         height = config.CONFIG["CUCU_BROWSER_WINDOW_HEIGHT"]
         width = config.CONFIG["CUCU_BROWSER_WINDOW_WIDTH"]

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -56,7 +56,6 @@ class Selenium(Browser):
 
         timeout = float(config.CONFIG["CUCU_SELENIUM_DEFAULT_TIMEOUT_S"])
         os.environ["GLOBAL_DEFAULT_TIMEOUT"] = str(timeout)
-        logger.debug(f"GLOBAL_DEFAULT_TIMEOUT: {timeout}")
 
         height = config.CONFIG["CUCU_BROWSER_WINDOW_HEIGHT"]
         width = config.CONFIG["CUCU_BROWSER_WINDOW_WIDTH"]

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ requires-dist = [
     { name = "pygls", specifier = "~=1.3.1" },
     { name = "pyyaml", specifier = "~=6.0.1" },
     { name = "requests", specifier = ">=2.31.0,<3.0.0" },
-    { name = "selenium", specifier = "~=4.25" },
+    { name = "selenium", specifier = "~=4.28" },
     { name = "tabulate", specifier = "~=0.9.0" },
     { name = "tenacity", specifier = "~=9.0.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.0.8"
+version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ requires-dist = [
     { name = "pygls", specifier = "~=1.3.1" },
     { name = "pyyaml", specifier = "~=6.0.1" },
     { name = "requests", specifier = ">=2.31.0,<3.0.0" },
-    { name = "selenium", specifier = "~=4.15" },
+    { name = "selenium", specifier = "~=4.25" },
     { name = "tabulate", specifier = "~=0.9.0" },
     { name = "tenacity", specifier = "~=9.0.0" },
 ]
@@ -976,7 +976,7 @@ wheels = [
 
 [[package]]
 name = "selenium"
-version = "4.24.0"
+version = "4.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -986,9 +986,9 @@ dependencies = [
     { name = "urllib3", extra = ["socks"] },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/ba/02f65b140f47c85a9d52c67cb19417ec8c97eb46547c3aa93f2b077fa276/selenium-4.24.0.tar.gz", hash = "sha256:88281e5b5b90fe231868905d5ea745b9ee5e30db280b33498cc73fb0fa06d571", size = 952221 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/38/d62d4e8da649ad699b02eb1e95c3cfc20ff400744b9417b9093c5daebd4b/selenium-4.28.1.tar.gz", hash = "sha256:0072d08670d7ec32db901bd0107695a330cecac9f196e3afb3fa8163026e022a", size = 981633 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/5aac23e57d61707f91914506902e621632de8dc56b60446459901469b9e2/selenium-4.24.0-py3-none-any.whl", hash = "sha256:42c23f60753d5415b261b236cecbd69bd4eb5271e1563915f546b443cb6b71c6", size = 9579812 },
+    { url = "https://files.pythonhosted.org/packages/a0/9f/34d0ec09b0dd6fb7b08b93eb4b7b80049e0b9db0ba7f81ad814c9be78b8f/selenium-4.28.1-py3-none-any.whl", hash = "sha256:4238847e45e24e4472cfcf3554427512c7aab9443396435b1623ef406fff1cc1", size = 9530373 },
 ]
 
 [[package]]


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
selenium 4.25 introduced a bug when explicitly setting overall timeout

Issue Number: https://dominodatalab.atlassian.net/browse/QE-17291

## What is the new behavior?
- Chore - update for selenium 4.28
- Chore - update CI with selenium docker images to 126

## Does this PR introduce a breaking change?
- [x] Yes (but only if you have selenium pre 4.25)
- [ ] No

## Other information
