### PR TITLE
chore - change package homepage to wiki page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.10
+- Chore - change package homepage to wiki page
+
 ## 1.0.9
 - Chore - update for selenium 4.28
 - Chore - update CI with selenium docker images to 126

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.0.9"
+version = "1.0.10"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }
@@ -65,7 +65,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage  = "https://github.com/dominodatalab/cucu"
+Homepage  = "https://github.com/dominodatalab/cucu/wiki"
 Download  = "https://pypi.org/project/cucu/"
 "Source Code" = "https://github.com/dominodatalab/cucu"
 

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
homepage in pypi points to github repo

Issue Number: https://dominodatalab.atlassian.net/browse/QE-16942

## What is the new behavior?
homepage in pypi points to github repo wiki page

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
This introduces the GH wiki for cucu and so I came up with an announcement here: https://github.com/dominodatalab/cucu/wiki/Announcing-cucu!
