### PR TITLE
QE-17615 Track and log how fuzzy finds elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.10
+
+- Add - logging to provide more insight into what Fuzzy is doing
 
 ## 1.3.9
 - Fix - re-add CONFIG["SCNEARIO_RUN_ID"]

--- a/features/flow_control/before_retry_handlers.feature
+++ b/features/flow_control/before_retry_handlers.feature
@@ -42,7 +42,9 @@ Feature: Before retry handlers
           Given I start a webserver at directory "data/www" and save the port to the variable "PORT" .*
             And I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/links.html" .*
             [\s\S]*
+      .* INFO Fuzzy found .*
       .* INFO handled the pesky button buttons!
+      .* INFO Fuzzy found .*
            Then I wait to see the button "button with child" .*
 
       1 feature passed, 0 failed, 0 skipped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.3.9"
+version = "1.3.10"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }

--- a/src/cucu/fuzzy/core.py
+++ b/src/cucu/fuzzy/core.py
@@ -97,6 +97,7 @@ def find(
         str(index),
         str(direction.value),
         name_within_thing,
+        "true"
     ]
 
     def execute_fuzzy_find():
@@ -104,4 +105,9 @@ def find(
         script = f"return cucu.fuzzy_find({','.join(args)});"
         return browser.execute(script)
 
-    return search_in_all_frames(browser, execute_fuzzy_find)
+    fuzzy_return = search_in_all_frames(browser, execute_fuzzy_find)
+    if fuzzy_return is None:
+        logger.info("Fuzzy found no element.")
+        return None
+    logger.info("Fuzzy found element by search term {}".format(fuzzy_return[1]))
+    return fuzzy_return[0]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -254,7 +254,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.3.9"
+version = "1.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Fuzzy operates in a completely opaque way, providing no information to the end user on how it selects which element to interact with.

Issue Number: https://dominodatalab.atlassian.net/browse/QE-17615

## What is the new behavior?
Track which elements are found with which type of selector in Fuzzy, and communicate that back to cucu so it can log the general form of the selector that was used to retrieve the element from the DOM.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
