### PR TITLE
QE-18143 fix browser state after tab info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.4
+- Fix - restore state after tab info
+- Change - make CONFIG yaml dump more robust
+- Chore - change to use uv-build packaging
+
 ## 1.2.3
 - Add - additional tab information steps
 - Change - retry open a browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 
 ## 1.2.4
 - Fix - restore state after tab info
+- Change - replace offset with start time in step html report
 - Change - make CONFIG yaml dump more robust
 - Chore - change to use uv-build packaging
 

--- a/features/browser/browser_window_managemenet.feature
+++ b/features/browser/browser_window_managemenet.feature
@@ -41,7 +41,7 @@ Feature: Browser window management
   Scenario: User gets appropriate error when checking browser title
     Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
      When I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/links.html"
-     Then I expect the following step to fail with "unexpected browser title, got "Links!""
+     Then I expect the following step to fail with "unexpected browser title, got "Links!"
      """
      Then I should see the browser title is "foo"
      """

--- a/features/cli/run_with_workers.feature
+++ b/features/cli/run_with_workers.feature
@@ -10,7 +10,7 @@ Feature: Run with workers
      When I run the command "cucu run data/features/slow_features --workers 5 --results {CUCU_RESULTS_DIR}/slow_features_with_workers" and expect exit code "0"
      Then I should see the previous step took less than "25" seconds
 
-  Scenario: User gets a report even when running with workesr
+  Scenario: User gets a report even when running with workers
     Given I run the command "cucu run data/features/slow_features --workers 4 --generate-report --report {CUCU_RESULTS_DIR}/generate_report_with_workers_report --results {CUCU_RESULTS_DIR}/generate_report_with_workers_results" and expect exit code "0"
      Then I should see a file at "{CUCU_RESULTS_DIR}/generate_report_with_workers_report/index.html"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.2.3"
+version = "1.2.4"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }
@@ -65,8 +65,8 @@ Download  = "https://pypi.org/project/cucu/"
 cucu = "cucu.cli:main"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.7.19,<0.8.0"]
+build-backend = "uv_build"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -258,17 +258,21 @@ class Selenium(Browser):
         }
 
     def get_all_tabs_info(self):
+        window_handles = self.driver.window_handles
+        current_window = self.driver.current_window_handle
         tabs_info = []
-        handles = self.driver.window_handles
-        for idx, handle in enumerate(handles):
+
+        for handle in window_handles:
             self.driver.switch_to.window(handle)
             tabs_info.append(
                 {
-                    "index": idx,
                     "title": self.driver.title,
                     "url": self.driver.current_url,
                 }
             )
+
+        # Switch back to the original window
+        self.driver.switch_to.window(current_window)
 
         return tabs_info
 

--- a/src/cucu/config.py
+++ b/src/cucu/config.py
@@ -313,7 +313,14 @@ class Config(dict):
                     v = f"'{v}'"
                 config[k] = v
 
-        return yaml.dump(config)
+        # Resolve non-atomic classes to their string representation
+        yaml.representer.SafeRepresenter.add_representer(
+            None,
+            lambda dumper, data: dumper.represent_scalar(
+                "tag:yaml.org,2002:str", str(data)
+            ),
+        )
+        return yaml.safe_dump(config)
 
 
 # global config object

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -75,7 +75,7 @@
                 {% endif %}
             </td>
             <td style="text-align: right; margin-top: auto;" class="col-2">
-                <pre style="display: inline; color: gray;">Offset and Duration (s)</pre>
+                <pre style="display: inline; color: gray;">Start Time and Duration (s)</pre>
             </td>
         </tr>
         {% for step in steps %}
@@ -88,7 +88,7 @@
             {% if step['result'] is defined %}
                 {% set step_status = step['result']['status'] %}
                 {% if step['result']['status'] == 'failed' or step['result']['status'] == 'passed' %}
-                    {% set step_timing = "{} for {:.3f}s".format(step["result"]["time_offset"].strftime("%H:%M:%S"), step["result"]["duration"]) %}
+                    {% set step_timing = "{} for {:.3f}s".format(step["result"]["timestamp"].strftime("%H:%M:%S"), step["result"]["duration"]) %}
                     {% set step_start = step["result"]["timestamp"] %}
                 {% endif %}
             {% else %}

--- a/src/cucu/steps/browser_steps.py
+++ b/src/cucu/steps/browser_steps.py
@@ -254,8 +254,8 @@ def save_browser_tabs_info_to_variable(ctx, variable):
     ctx.check_browser_initialized()
     tabs_info = ctx.browser.get_all_tabs_info()
     lst_tab_info = [
-        f"tab({tab['index'] + 1}): {tab['title']}, url: {tab['url']}"
-        for tab in tabs_info
+        f"tab({index + 1}): {tab['title']}, url: {tab['url']}"
+        for index, tab in enumerate(tabs_info)
     ]
     config.CONFIG[variable] = lst_tab_info
 
@@ -274,8 +274,8 @@ def list_current_browser_tab_info(ctx):
 def list_browser_tabs_info(ctx):
     ctx.check_browser_initialized()
     all_tabs_info = ctx.browser.get_all_tabs_info()
-    for tab in all_tabs_info:
-        tab_index = tab["index"] + 1
+    for index, tab in enumerate(all_tabs_info):
+        tab_index = index + 1
         title = tab["title"]
         url = tab["url"]
         print(f"\ntab({tab_index}): {title}\nurl: {url}\n")

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.2.3"
+version = "1.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## 1.2.4
- Fix - restore state after tab info
- Change - replace offset with start time in step html report
- Change - make CONFIG yaml dump more robust
- Chore - change to use uv-build packaging