### PR TITLE
Many minor changes in prep for db recording

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,12 @@ jobs:
             uv run cucu run features --workers 8 --selenium-remote-url http://localhost:4444 --generate-report --junit junit_results --browser "<<parameters.browser>>"
       - run:
           name: run unit tests
-          command: uv run coverage run -m pytest --junit-xml=results/unit-tests.xml
+          command: |
+            set -euxo pipefail
+            mv results cucu-results
+            uv run coverage run -m pytest --junit-xml=pytest-results/unit-tests.xml
+            mv cucu-results results
+            mv pytest-results/unit-tests.xml results/unit-tests.xml
       - run:
           name: code_coverage_check
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.5
+- Chore - CI - fix results to not be deleted by pytest
+- Chore - makefile - make fix more like make lint
+
 ## 1.2.4
 - Fix - restore state after tab info
 - Change - replace offset with start time in step html report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 - Change - use pathlib for paths
 - Add - metadata to features, scenarios and steps
 - Add - CONFIG now can save multiple snapshots in a stack
+- Add - section level info to steps
 
 ## 1.2.4
 - Fix - restore state after tab info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 - Change - replace offset with start time in step html report
 - Change - make CONFIG yaml dump more robust
 - Chore - change to use uv-build packaging
+- Change - extract generate_short_id to utils
 
 ## 1.2.3
 - Add - additional tab information steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 - Change - rename .start_timestamp => to .start_at
 - Add - debug and browser logs to steps
 - Change - use pathlib for paths
+- Add - metadata to features, scenarios and steps
 
 ## 1.2.4
 - Fix - restore state after tab info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 - Add - steps - add browser info and screenshot info
 - Add - features, scenarios and steps - add various metadata
 - Add - steps - add section level, seq and parent_seq info
+- Add - pytest-check for mulitple asserts
 - Change - extract generate_short_id to utils
 - Change - rename .start_timestamp => to .start_at
 - Change - use pathlib for paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 1.2.5
-- Chore - CI - fix results to not be deleted by pytest
-- Chore - makefile - make fix more like make lint
-- Change - minor update to scenarios
-- Change - rename .start_timestamp => to .start_at
-- Add - debug and browser logs to steps
-- Change - use pathlib for paths
-- Add - metadata to features, scenarios and steps
 - Add - CONFIG now can save multiple snapshots in a stack
+- Add - debug and browser logs to steps
+- Add - metadata to features, scenarios and steps
 - Add - section level info to steps
 - Change - extract generate_short_id to utils
+- Change - minor update to scenarios
+- Change - rename .start_timestamp => to .start_at
+- Change - use pathlib for paths
+- Chore - CI - fix results to not be deleted by pytest
+- Chore - makefile - make fix more like make lint
 
 ## 1.2.4
 - Fix - restore state after tab info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 - Chore - makefile - make fix more like make lint
 - Change - minor update to scenarios
 - Change - rename .start_timestamp => to .start_at
+- Add - debug and browser logs to steps
+- Change - use pathlib for paths
 
 ## 1.2.4
 - Fix - restore state after tab info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 - Chore - CI - fix results to not be deleted by pytest
 - Chore - makefile - make fix more like make lint
 - Change - minor update to scenarios
+- Change - rename .start_timestamp => to .start_at
 
 ## 1.2.4
 - Fix - restore state after tab info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 ## 1.2.5
 - Chore - CI - fix results to not be deleted by pytest
 - Chore - makefile - make fix more like make lint
+- Change - minor update to scenarios
 
 ## 1.2.4
 - Fix - restore state after tab info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 - Add - metadata to features, scenarios and steps
 - Add - CONFIG now can save multiple snapshots in a stack
 - Add - section level info to steps
+- Change - extract generate_short_id to utils
 
 ## 1.2.4
 - Fix - restore state after tab info
 - Change - replace offset with start time in step html report
 - Change - make CONFIG yaml dump more robust
 - Chore - change to use uv-build packaging
-- Change - extract generate_short_id to utils
 
 ## 1.2.3
 - Add - additional tab information steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 
 ## 1.2.5
 - Add - CONFIG now can save multiple snapshots in a stack
-- Add - steps - add debug log and browser log
-- Add - steps - add browser info and screenshot info
 - Add - features, scenarios and steps - add various metadata
-- Add - steps - add section level, seq and parent_seq info
 - Add - pytest-check for mulitple asserts
+- Add - steps - add browser info and screenshot info
+- Add - steps - add debug log and browser log
+- Add - steps - add section level, seq and parent_seq info
 - Change - extract generate_short_id to utils
 - Change - rename .start_timestamp => to .start_at
 - Change - use pathlib for paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 - Add - debug and browser logs to steps
 - Change - use pathlib for paths
 - Add - metadata to features, scenarios and steps
+- Add - CONFIG now can save multiple snapshots in a stack
 
 ## 1.2.4
 - Fix - restore state after tab info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 
 ## 1.2.5
 - Add - CONFIG now can save multiple snapshots in a stack
-- Add - debug and browser logs to steps
-- Add - metadata to features, scenarios and steps
-- Add - section level info to steps
+- Add - steps - add debug log and browser log
+- Add - steps - add browser info and screenshot info
+- Add - features, scenarios and steps - add various metadata
+- Add - steps - add section level, seq and parent_seq info
 - Change - extract generate_short_id to utils
-- Change - minor update to scenarios
 - Change - rename .start_timestamp => to .start_at
 - Change - use pathlib for paths
 - Chore - CI - fix results to not be deleted by pytest

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ fix:
 	uv sync
 	uv run ruff format .
 	uv run ruff check . --fix
+	SKIP=makefile uv run pre-commit run --show-diff-on-failure --from-ref origin/HEAD --to-ref HEAD
 	uv run cucu lint --fix features
 
 lint:

--- a/data/features/with_secret/scenario_with_sections.feature
+++ b/data/features/with_secret/scenario_with_sections.feature
@@ -19,10 +19,11 @@ Feature: Feature with sections
         * # Second section about
         # we shouldn't set a secret this way in production because the secret will end up
         # in the source code. However, in test, this is a simple way to mimic a secret
-        * ## Subsection
+        * ## Subsection Two
      When I set the variable "MY_SECRET" to "buzz"
 
         * ### Sub-subsection
+        * ## Just a subsection
         * #### Deep subsection
       And I write "{MY_SECRET}" into the input "input type=text"
      Then I should see the text "{MY_SECRET}"

--- a/features/cli/run_with_hooks.feature
+++ b/features/cli/run_with_hooks.feature
@@ -55,6 +55,7 @@ Feature: Run with hooks
       [\s\S]*
       .* DEBUG just logging some stuff from my before all hook
       Feature: Feature that simply echo's "Hello World"
+      [\s\S]*
       .* DEBUG just logging some stuff from my before scenario hook
       .* DEBUG HOOK before_scenario_log: passed ✅
 
@@ -73,9 +74,10 @@ Feature: Run with hooks
       .* DEBUG HOOK download_mht_data: passed ✅
       .* DEBUG just logging some stuff from my after scenario hook
       .* DEBUG HOOK after_scenario_log: passed ✅
-      .* DEBUG HOOK download_browser_logs: passed ✅
+      .* DEBUG HOOK download_browser_log: passed ✅
 
       .* DEBUG just logging some stuff from my after all hook
+      [\s\S]*
       1 feature passed, 0 failed, 0 skipped
       1 scenario passed, 0 failed, 0 skipped
       2 steps passed, 0 failed, 0 skipped, 0 undefined
@@ -121,6 +123,7 @@ Feature: Run with hooks
       """
       [\s\S]*
       Feature: Feature that runs after this scenario hooks in LIFO order.
+      [\s\S]*
 
         Scenario: This is a scenario that runs after this scenario hooks in LIFO order
           Given I run the following steps after the current scenario-1     # .*
@@ -131,8 +134,9 @@ Feature: Run with hooks
       .* DEBUG HOOK after_this_scenario_2: passed ✅
       .* DEBUG just logging some stuff from first_after_this_scenario_hook_1
       .* DEBUG HOOK after_this_scenario_1: passed ✅
-      .* DEBUG HOOK download_browser_logs: passed ✅
+      .* DEBUG HOOK download_browser_log: passed ✅
 
+      [\s\S]*
       1 feature passed, 0 failed, 0 skipped
       1 scenario passed, 0 failed, 0 skipped
       2 steps passed, 0 failed, 0 skipped, 0 undefined

--- a/features/cli/run_with_logging.feature
+++ b/features/cli/run_with_logging.feature
@@ -6,7 +6,7 @@ Feature: Run with logging
     Given I run the command "cucu run data/features/feature_with_logging.feature --results {CUCU_RESULTS_DIR}/default-logging-results --no-color-output" and save stdout to "STDOUT" and expect exit code "0"
      Then I should see "{STDOUT}" matches the following
       """
-      Feature: Feature with logging
+      [\s\S]*Feature: Feature with logging
 
         Scenario: Logging at various levels
       .* INFO hello
@@ -27,6 +27,7 @@ Feature: Run with logging
       """
       [\s\S]*
       Feature: Feature with logging
+      [\s\S]*
 
         Scenario: Logging at various levels
       .* INFO hello
@@ -37,8 +38,9 @@ Feature: Run with logging
             And I log "world" at level "warning" \s*# .*
       .* DEBUG No browsers - skipping MHT webpage snapshot
       .* DEBUG HOOK download_mht_data: passed ✅
-      .* DEBUG HOOK download_browser_logs: passed ✅
+      .* DEBUG HOOK download_browser_log: passed ✅
 
+      [\s\S]*
       1 feature passed, 0 failed, 0 skipped
       1 scenario passed, 0 failed, 0 skipped
       3 steps passed, 0 failed, 0 skipped, 0 undefined

--- a/features/cli/vars.feature
+++ b/features/cli/vars.feature
@@ -25,7 +25,7 @@ Feature: Vars
       # can see a built in variable
      Then I should see "{STDOUT}" contains the following:
       """
-      FEATURE_RESULTS_DIR
+      SCENARIO_DOWNLOADS_DIR
       """
       # can see a custom variable defined in the underlying project
       And I should see "{STDOUT}" contains the following:

--- a/features/flow_control/run_steps_conditionally.feature
+++ b/features/flow_control/run_steps_conditionally.feature
@@ -16,7 +16,7 @@ Feature: Run steps conditionally
       """
       When I create a file at "{SCENARIO_RESULTS_DIR}/conditional_steps/this-should-exist" with the following:
        '''
-       this file should not have been created
+       this file should have been created
        '''
       """
      Then I should see a file at "{SCENARIO_RESULTS_DIR}/conditional_steps/this-should-exist"
@@ -35,7 +35,7 @@ Feature: Run steps conditionally
       """
       When I create a file at "{SCENARIO_RESULTS_DIR}/conditional_steps/this-should-exist" with the following:
        '''
-       this file should not have been created
+       this file should have been created
        '''
       """
      Then I should see a file at "{SCENARIO_RESULTS_DIR}/conditional_steps/this-should-exist"
@@ -54,7 +54,7 @@ Feature: Run steps conditionally
       """
       When I create a file at "{SCENARIO_RESULTS_DIR}/conditional_steps/this-should-exist" with the following:
        '''
-       this file should not have been created
+       this file should have been created
        '''
       """
      Then I should see a file at "{SCENARIO_RESULTS_DIR}/conditional_steps/this-should-exist"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.2.4"
+version = "1.2.5"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ exclude = [
 dev-dependencies = [
     "pre-commit>=3.8.0",
     "pytest~=8.4.0",
+    "pytest-check>=2.5.3",
     "ruff>=0.6.4",
 ]
 

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -1,5 +1,4 @@
 import datetime
-import hashlib
 import json
 import os
 import sys
@@ -10,7 +9,7 @@ from functools import partial
 from cucu import config, init_scenario_hook_variables, logger
 from cucu.config import CONFIG
 from cucu.page_checks import init_page_checks
-from cucu.utils import ellipsize_filename, take_screenshot
+from cucu.utils import ellipsize_filename, generate_short_id, take_screenshot
 
 CONFIG.define(
     "FEATURE_RESULTS_DIR",
@@ -122,9 +121,7 @@ def before_scenario(ctx, scenario):
         logger.init_debug_logger(ctx.scenario_debug_log_file)
 
     # internal cucu config variables
-    CONFIG["SCENARIO_RUN_ID"] = hashlib.sha256(
-        str(time.perf_counter()).encode("utf-8")
-    ).hexdigest()[:7]
+    CONFIG["SCENARIO_RUN_ID"] = generate_short_id()
 
     # run before all scenario hooks
     for hook in CONFIG["__CUCU_BEFORE_SCENARIO_HOOKS"]:

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -1,21 +1,20 @@
-import datetime
 import json
-import os
 import sys
-import time
 import traceback
+from datetime import datetime
 from functools import partial
+from pathlib import Path
 
 from cucu import config, init_scenario_hook_variables, logger
 from cucu.config import CONFIG
 from cucu.page_checks import init_page_checks
-from cucu.utils import ellipsize_filename, generate_short_id, take_screenshot
-
-CONFIG.define(
-    "FEATURE_RESULTS_DIR",
-    "the results directory for the currently executing feature",
-    default=None,
+from cucu.utils import (
+    TeeStream,
+    ellipsize_filename,
+    generate_short_id,
+    take_screenshot,
 )
+
 CONFIG.define(
     "SCENARIO_RESULTS_DIR",
     "the results directory for the currently executing scenario",
@@ -43,7 +42,7 @@ def check_browser_initialized(ctx):
 
 def before_all(ctx):
     CONFIG["__CUCU_CTX"] = ctx
-    CONFIG.snapshot()
+    CONFIG.snapshot("before_all")
     ctx.check_browser_initialized = partial(check_browser_initialized, ctx)
     for hook in CONFIG["__CUCU_BEFORE_ALL_HOOKS"]:
         hook(ctx)
@@ -54,14 +53,13 @@ def after_all(ctx):
     for hook in CONFIG["__CUCU_AFTER_ALL_HOOKS"]:
         hook(ctx)
 
+    CONFIG.restore(with_pop=True)
+
 
 def before_feature(ctx, feature):
     if config.CONFIG["CUCU_RESULTS_DIR"] is not None:
-        results_dir = config.CONFIG["CUCU_RESULTS_DIR"]
-        ctx.feature_dir = os.path.join(
-            results_dir, ellipsize_filename(feature.name)
-        )
-        CONFIG["FEATURE_RESULTS_DIR"] = ctx.feature_dir
+        results_dir = Path(config.CONFIG["CUCU_RESULTS_DIR"])
+        ctx.feature_dir = results_dir / ellipsize_filename(feature.name)
 
 
 def after_feature(ctx, feature):
@@ -84,43 +82,46 @@ def before_scenario(ctx, scenario):
     ctx.step_index = 0
     ctx.browsers = []
     ctx.browser = None
+    ctx.section_step_stack = []
 
     # reset the step timer dictionary
     ctx.step_timers = {}
 
     if config.CONFIG["CUCU_RESULTS_DIR"] is not None:
-        ctx.scenario_dir = os.path.join(
-            ctx.feature_dir, ellipsize_filename(scenario.name)
-        )
+        ctx.scenario_dir = ctx.feature_dir / ellipsize_filename(scenario.name)
         CONFIG["SCENARIO_RESULTS_DIR"] = ctx.scenario_dir
-        os.makedirs(ctx.scenario_dir, exist_ok=True)
+        ctx.scenario_dir.mkdir(parents=True, exist_ok=True)
 
-        ctx.scenario_downloads_dir = os.path.join(
-            ctx.scenario_dir, "downloads"
-        )
+        ctx.scenario_downloads_dir = ctx.scenario_dir / "downloads"
         CONFIG["SCENARIO_DOWNLOADS_DIR"] = ctx.scenario_downloads_dir
-        os.makedirs(ctx.scenario_downloads_dir, exist_ok=True)
+        ctx.scenario_downloads_dir.mkdir(parents=True, exist_ok=True)
 
-        ctx.scenario_logs_dir = os.path.join(ctx.scenario_dir, "logs")
+        ctx.scenario_logs_dir = ctx.scenario_dir / "logs"
         CONFIG["SCENARIO_LOGS_DIR"] = ctx.scenario_logs_dir
-        os.makedirs(ctx.scenario_logs_dir, exist_ok=True)
+        ctx.scenario_logs_dir.mkdir(parents=True, exist_ok=True)
 
-        cucu_debug_filepath = os.path.join(
-            ctx.scenario_logs_dir, "cucu.debug.console.log"
-        )
+        cucu_debug_log_path = ctx.scenario_logs_dir / "cucu.debug.console.log"
         ctx.scenario_debug_log_file = open(
-            cucu_debug_filepath, "w", encoding=sys.stdout.encoding
+            cucu_debug_log_path, "w", encoding=sys.stdout.encoding
         )
+        ctx.scenario_debug_log_tee = TeeStream(ctx.scenario_debug_log_file)
 
         # redirect stdout, stderr and setup a logger at debug level to fill
         # the scenario cucu.debug.log file which makes it possible to have
         # debug logging for every single scenario run without polluting the
         # console logs at runtime.
-        sys.stdout.set_other_stream(ctx.scenario_debug_log_file)
-        sys.stderr.set_other_stream(ctx.scenario_debug_log_file)
-        logger.init_debug_logger(ctx.scenario_debug_log_file)
+        sys.stdout.set_other_stream(ctx.scenario_debug_log_tee)
+        sys.stderr.set_other_stream(ctx.scenario_debug_log_tee)
+        logger.init_debug_logger(ctx.scenario_debug_log_tee)
 
-    # internal cucu config variables
+        # capture browser logs using TeeStream since each call clears the log
+        ctx.browser_log_file = open(
+            ctx.scenario_logs_dir / "browser_console.log.txt",
+            "w",
+            encoding="utf-8",
+        )
+        ctx.browser_log_tee = TeeStream(ctx.browser_log_file)
+
     CONFIG["SCENARIO_RUN_ID"] = generate_short_id()
 
     # run before all scenario hooks
@@ -176,12 +177,10 @@ def after_scenario(ctx, scenario):
         if len(ctx.browsers) != 0:
             logger.debug("quitting browser between sessions")
 
-        run_after_scenario_hook(ctx, scenario, download_browser_logs)
+        run_after_scenario_hook(ctx, scenario, download_browser_log)
 
-    cucu_config_filepath = os.path.join(
-        ctx.scenario_logs_dir, "cucu.config.yaml.txt"
-    )
-    with open(cucu_config_filepath, "w") as config_file:
+    cucu_config_path = ctx.scenario_logs_dir / "cucu.config.yaml.txt"
+    with open(cucu_config_path, "w") as config_file:
         config_file.write(CONFIG.to_yaml_without_secrets())
 
 
@@ -195,45 +194,41 @@ def download_mht_data(ctx):
             mht_filename = (
                 f"browser{index if len(ctx.browsers) > 1 else ''}_snapshot.mht"
             )
-            mht_pathname = os.path.join(
-                CONFIG["SCENARIO_LOGS_DIR"],
-                mht_filename,
-            )
+            mht_pathname = CONFIG["SCENARIO_LOGS_DIR"] / mht_filename
             logger.debug(f"Saving MHT webpage snapshot: {mht_filename}")
             browser.download_mht(mht_pathname)
 
 
-def download_browser_logs(ctx):
+def download_browser_log(ctx):
     # close the browser unless someone has set the keep browser alive
     # environment variable which allows tests to reuse the same browser
     # session
 
     for browser in ctx.browsers:
-        # save the browser logs to the current scenarios results directory
-        browser_log_filepath = os.path.join(
-            ctx.scenario_logs_dir, "browser_console.log.txt"
-        )
-
-        os.makedirs(os.path.dirname(browser_log_filepath), exist_ok=True)
-        with open(browser_log_filepath, "w") as output:
-            for log in browser.get_log():
-                output.write(f"{json.dumps(log)}\n")
-
         browser.quit()
+
+    ctx.browser_log_file.close()
 
     ctx.browsers = []
 
 
 def before_step(ctx, step):
-    # trims the last 3 digits of the microseconds
-    step.start_at = datetime.datetime.now().isoformat()[:-3]
+    step.start_at = datetime.now().isoformat()[:-3]
 
     sys.stdout.captured()
     sys.stderr.captured()
 
+    # Reset the debug log buffer for this step
+    if hasattr(ctx, "scenario_debug_log_tee"):
+        ctx.scenario_debug_log_tee.clear()
+
     ctx.current_step = step
     ctx.current_step.has_substeps = False
-    ctx.start_time = time.monotonic()
+    ctx.section_level = None
+    step.seq = ctx.step_index + 1
+    step.parent_seq = (
+        ctx.section_step_stack[-1].seq if ctx.section_step_stack else 0
+    )
 
     CONFIG["__STEP_SCREENSHOT_COUNT"] = 0
 
@@ -246,8 +241,18 @@ def after_step(ctx, step):
     step.stdout = sys.stdout.captured()
     step.stderr = sys.stderr.captured()
 
-    ctx.end_time = time.monotonic()
-    ctx.previous_step_duration = ctx.end_time - ctx.start_time
+    # Capture debug output from the TeeStream for this step
+    if hasattr(ctx, "scenario_debug_log_tee"):
+        step.debug_output = ctx.scenario_debug_log_tee.getvalue()
+    else:
+        step.debug_output = ""
+
+    step.end_at = datetime.now().isoformat()[:-3]
+
+    # calculate duration from ISO timestamps
+    start_at = datetime.fromisoformat(step.start_at)
+    end_at = datetime.fromisoformat(step.end_at)
+    ctx.previous_step_duration = (end_at - start_at).total_seconds()
 
     # when set this means we're running in parallel mode using --workers and
     # we want to see progress reported using simply dots
@@ -293,3 +298,26 @@ def after_step(ctx, step):
     # run after all step hooks
     for hook in CONFIG["__CUCU_AFTER_STEP_HOOKS"]:
         hook(ctx)
+
+    # Capture browser logs and info for this step
+    step.browser_logs = ""
+
+    browser_info = {"has_browser": False}
+    if ctx.browser:
+        browser_logs = []
+        for log in ctx.browser.get_log():
+            log_entry = json.dumps(log)
+            browser_logs.append(log_entry)
+            ctx.browser_log_tee.write(f"{log_entry}\n")
+        step.browser_logs = "\n".join(browser_logs)
+
+        tab_info = ctx.browser.get_tab_info()
+        all_tabs = ctx.browser.get_all_tabs_info()
+
+        browser_info = {
+            "current_tab_index": tab_info["index"],
+            "all_tabs": all_tabs,
+            "browser_type": ctx.browser.driver.name,
+        }
+
+    step.browser_info = json.dumps(browser_info)

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -226,7 +226,7 @@ def download_browser_logs(ctx):
 
 def before_step(ctx, step):
     # trims the last 3 digits of the microseconds
-    step.start_timestamp = datetime.datetime.now().isoformat()[:-3]
+    step.start_at = datetime.datetime.now().isoformat()[:-3]
 
     sys.stdout.captured()
     sys.stderr.captured()

--- a/src/cucu/formatter/cucu.py
+++ b/src/cucu/formatter/cucu.py
@@ -185,7 +185,7 @@ class CucuFormatter(Formatter):
             max_line_length = self.calculate_max_line_length()
             status_text = ""
             if self.show_timings:
-                start = step.start_timestamp
+                start = step.start_at
                 duration = f"{step.duration:.3f}"
                 status_text += f" # started at {start} took {duration}s"
 

--- a/src/cucu/formatter/json.py
+++ b/src/cucu/formatter/json.py
@@ -157,7 +157,7 @@ class CucuJSONFormatter(Formatter):
 
         timestamp = None
         if step.status.name in ["passed", "failed"]:
-            timestamp = step.start_timestamp
+            timestamp = step.start_at
 
             step_variables = CONFIG.expand(step.name)
 

--- a/src/cucu/steps/section_steps.py
+++ b/src/cucu/steps/section_steps.py
@@ -1,3 +1,5 @@
+import logging
+
 from behave import use_step_matcher
 
 from cucu import step
@@ -6,7 +8,7 @@ use_step_matcher("re")  # use regex to match section heading patterns
 
 
 @step("(#{1,4})\\s*(.*)")
-def section_step(ctx, heading_level, section_text):
+def section_step(ctx, section_level, section_text):
     """
     A section heading step that organizes scenarios into logical sections.
 
@@ -19,7 +21,24 @@ def section_step(ctx, heading_level, section_text):
     The number of # characters determines the heading level (1-4).
     This step is a no-op but provides structure in the HTML report.
     """
-    pass
+    step = ctx.current_step
+    step.section_level = len(section_level)
+    step.parent_seq = 0
+
+    while len(ctx.section_step_stack):
+        latest_section = ctx.section_step_stack[-1]
+        if latest_section.section_level < step.section_level:
+            step.parent_seq = latest_section.seq
+            break
+        ctx.section_step_stack.pop()
+        logging.debug(
+            f"Section: exited '{latest_section.name}' (level {latest_section.section_level})"
+        )
+
+    ctx.section_step_stack.append(ctx.current_step)
+    logging.debug(
+        f"Section: entering '{step.name}' (level {step.section_level})"
+    )
 
 
 use_step_matcher("parse")  # set this back to cucu's default matcher parser

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -234,6 +234,10 @@ def take_saw_element_screenshot(ctx, thing, name, index, element=None):
 
 
 def take_screenshot(ctx, step_name, label="", element=None):
+    step = ctx.current_step
+    if not hasattr(step, "screenshots"):
+        step.screenshots = []
+
     screenshot_dir = os.path.join(
         ctx.scenario_dir, get_step_image_dir(ctx.step_index, step_name)
     )
@@ -279,6 +283,20 @@ def take_screenshot(ctx, step_name, label="", element=None):
             })();
         """
         ctx.browser.execute(clear_highlight, element)
+
+    screenshot = {
+        "step_name": step_name,
+        "label": label,
+        "element": element,
+        "location": f"({element.location['x']},{element.location['y']})"
+        if element
+        else "",
+        "size": f"({element.size['width']},{element.size['height']})"
+        if element
+        else "",
+        "filepath": filepath,
+    }
+    step.screenshots.append(screenshot)
 
     if CONFIG["CUCU_MONITOR_PNG"]:
         shutil.copyfile(filepath, CONFIG["CUCU_MONITOR_PNG"])

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -309,3 +309,31 @@ def find_n_click_input_parent_label(ctx, input_element):
 def is_element_size_zero(element):
     size = element.size
     return size["width"] == 0 and size["height"] == 0
+
+
+class TeeStream:
+    """
+    A stream that writes to both a file stream and captures content in an internal buffer.
+    Provides file-like accessors to read the captured content.
+    """
+
+    def __init__(self, file_stream):
+        self.file_stream = file_stream
+        self.string_buffer = []
+
+    def write(self, data):
+        self.file_stream.write(data)
+        self.string_buffer.append(data)
+
+    def flush(self):
+        self.file_stream.flush()
+
+    def getvalue(self):
+        return "".join(self.string_buffer)
+
+    def read(self):
+        return self.getvalue()
+
+    def clear(self):
+        """Clear the internal buffer."""
+        self.string_buffer = []

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -3,10 +3,12 @@ various cucu utilities can be placed here and then exposed publicly through
 the src/cucu/__init__.py
 """
 
+import hashlib
 import logging
 import os
 import pkgutil
 import shutil
+import time
 
 import humanize
 from selenium.webdriver.common.by import By
@@ -39,6 +41,16 @@ GHERKIN_TABLEFORMAT = TableFormat(
 
 class StopRetryException(Exception):
     pass
+
+
+def generate_short_id():
+    """
+    Generate a short 7-character ID based on current performance counter.
+    Used for both cucu_run_id and scenario_run_id.
+    """
+    return hashlib.sha256(
+        str(time.perf_counter()).encode("utf-8")
+    ).hexdigest()[:7]
 
 
 def format_gherkin_table(table, headings=[], prefix=""):
@@ -76,7 +88,7 @@ def run_steps(ctx, steps_text):
     steps = ctx.feature.parser.parse_steps(steps_text)
 
     current_step = ctx.current_step
-    current_step_start_time = ctx.start_time
+    current_step_start_at = current_step.start_at
 
     # XXX: I want to get back to this and find a slightly better way to handle
     #      these substeps without mucking around with so much state in behave
@@ -101,7 +113,7 @@ def run_steps(ctx, steps_text):
             ctx.text = original_text
     finally:
         ctx.current_step = current_step
-        ctx.start_time = current_step_start_time
+        ctx.current_step.start_at = current_step_start_at
 
     return True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ import tempfile
 import pytest
 
 import cucu
-from cucu.config import CONFIG, leaf_map
+from cucu.config import CONFIG, Config, leaf_map
 
 
 def test_config_lookup_for_inexistent_is_none():
@@ -44,12 +44,12 @@ def test_config_resolve_leaves_unresolved_variables():
     assert CONFIG.resolve("{NOT_SET}") == ""
 
 
-def test_config_snapshot_and_restore_works():
+def test_config_push_and_pop_works():
     CONFIG["FOO"] = None
     CONFIG.snapshot()
     CONFIG["FOO"] = "bar"
     assert CONFIG["FOO"] == "bar"
-    CONFIG.restore()
+    CONFIG.restore(with_pop=True)
     assert CONFIG["FOO"] is None
 
 
@@ -131,3 +131,113 @@ def test_leaf_map():
     }
     actual = leaf_map(data, something)
     assert actual == expected
+
+
+def test_config_push_pop_stack_behavior():
+    config = Config()
+    config["key1"] = "value1"
+    config["key2"] = "value2"
+
+    # Take first snapshot
+    config.snapshot("first")
+    config["key2"] = "modified"
+    config["key3"] = "value3"
+
+    # Take second snapshot
+    config.snapshot("second")
+    config["key1"] = "again_modified"
+
+    # Test stack depth
+    assert len(config.snapshots) == 2
+
+    # Pop should restore to second snapshot
+    config.restore(with_pop=True)
+    assert config["key1"] == "value1"
+    assert config["key2"] == "modified"
+    assert config["key3"] == "value3"
+    assert len(config.snapshots) == 1
+
+    # Pop again should restore to first snapshot
+    config.restore(with_pop=True)
+    assert config["key1"] == "value1"
+    assert config["key2"] == "value2"
+    assert "key3" not in config
+    assert len(config.snapshots) == 0
+
+
+def test_config_restore_functionality():
+    # Test that restore restores to top of stack without popping
+    CONFIG["TEST"] = "initial"
+    CONFIG.snapshot()
+
+    CONFIG["TEST"] = "modified"
+    assert CONFIG["TEST"] == "modified"
+
+    CONFIG.restore()
+    assert CONFIG["TEST"] == "initial"
+
+    # Verify the stack still has the value (not popped)
+    CONFIG["TEST"] = "modified_again"
+    CONFIG.restore()
+    assert CONFIG["TEST"] == "initial"
+
+
+def test_config_empty_stack_operations_graceful():
+    # Clear any existing stack
+    CONFIG.snapshots = []
+
+    # Restore on empty stack should not raise error
+    CONFIG.restore()
+
+    # Pop on empty stack should not raise error
+    CONFIG.restore(with_pop=True)
+
+
+def test_config_named_snapshots():
+    config = Config()
+    config["key1"] = "value1"
+
+    # Take named snapshot
+    config.snapshot("first_snapshot")
+    config["key2"] = "value2"
+
+    # Take another named snapshot
+    config.snapshot("second_snapshot")
+    config["key3"] = "value3"
+
+    # Check snapshot names
+    names = config.list_snapshots()
+    assert names == ["first_snapshot", "second_snapshot"]
+
+    # Pop should restore to second snapshot
+    config.restore(with_pop=True)
+    assert "key3" not in config
+    assert config["key2"] == "value2"
+
+    # Check snapshot names after pop
+    names = config.list_snapshots()
+    assert names == ["first_snapshot"]
+
+
+def test_config_auto_generated_snapshot_names():
+    config = Config()
+    config["key1"] = "value1"
+
+    # Take unnamed snapshots
+    config.snapshot()  # should be snapshot_0
+    config.snapshot()  # should be snapshot_1
+
+    names = config.list_snapshots()
+    assert names == ["snapshot_0", "snapshot_1"]
+
+
+def test_config_empty_snapshots_list():
+    config = Config()
+
+    # Empty snapshots should return empty list
+    names = config.list_snapshots()
+    assert names == []
+
+    # restore and pop should handle empty snapshots gracefully
+    config.restore()  # should not raise
+    config.restore(with_pop=True)  # should not raise

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,16 +23,27 @@ def test_config_lookup_env_precedes_internal_value():
 
 def test_config_true_method():
     CONFIG["VAR1"] = "true"
-    check.is_true(CONFIG.true("VAR1"), "Config should recognize 'true' as true")
-    check.is_false(CONFIG.true("INEXISTENT"), "Non-existent config should return False")
+    check.is_true(
+        CONFIG.true("VAR1"), "Config should recognize 'true' as true"
+    )
+    check.is_false(
+        CONFIG.true("INEXISTENT"), "Non-existent config should return False"
+    )
 
 
 def test_config_false_method():
     CONFIG["VAR1"] = "false"
-    check.is_true(CONFIG.false("VAR1"), "Config should recognize 'false' as false")
+    check.is_true(
+        CONFIG.false("VAR1"), "Config should recognize 'false' as false"
+    )
     CONFIG["VAR1"] = "true"
-    check.is_false(CONFIG.false("VAR1"), "Config should not treat 'true' as false")
-    check.is_true(CONFIG.false("INEXISTENT"), "Non-existent config should return True for false()")
+    check.is_false(
+        CONFIG.false("VAR1"), "Config should not treat 'true' as false"
+    )
+    check.is_true(
+        CONFIG.false("INEXISTENT"),
+        "Non-existent config should return True for false()",
+    )
 
 
 def test_config_resolves_variables():
@@ -96,7 +107,11 @@ def test_config_expand_variables_handles_existent_and_non_existent_variables():
         "var1": "value1",
         "var2": None,
     }
-    check.equal(result, expected, "Expand should handle both existing and non-existing variables")
+    check.equal(
+        result,
+        expected,
+        "Expand should handle both existing and non-existing variables",
+    )
 
 
 def test_config_expand_variables_handles_recursive_variable_resolution():
@@ -107,7 +122,9 @@ def test_config_expand_variables_handles_recursive_variable_resolution():
     expected = {
         "var1": "value2",
     }
-    check.equal(result, expected, "Expand should resolve recursive variable references")
+    check.equal(
+        result, expected, "Expand should resolve recursive variable references"
+    )
 
 
 def test_config_expand_with_custom_variable_handling():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import tempfile
 
 import pytest
+import pytest_check as check
 
 import cucu
 from cucu.config import CONFIG, Config, leaf_map
@@ -22,16 +23,16 @@ def test_config_lookup_env_precedes_internal_value():
 
 def test_config_true_method():
     CONFIG["VAR1"] = "true"
-    assert CONFIG.true("VAR1")
-    assert CONFIG.true("INEXISTENT") is False
+    check.is_true(CONFIG.true("VAR1"), "Config should recognize 'true' as true")
+    check.is_false(CONFIG.true("INEXISTENT"), "Non-existent config should return False")
 
 
 def test_config_false_method():
     CONFIG["VAR1"] = "false"
-    assert CONFIG.false("VAR1")
+    check.is_true(CONFIG.false("VAR1"), "Config should recognize 'false' as false")
     CONFIG["VAR1"] = "true"
-    assert CONFIG.false("VAR1") is False
-    assert CONFIG.false("INEXISTENT")
+    check.is_false(CONFIG.false("VAR1"), "Config should not treat 'true' as false")
+    check.is_true(CONFIG.false("INEXISTENT"), "Non-existent config should return True for false()")
 
 
 def test_config_resolves_variables():
@@ -90,19 +91,23 @@ def test_config_custom_variable_resolution():
 def test_config_expand_variables_handles_existent_and_non_existent_variables():
     CONFIG["var1"] = "value1"
 
-    assert CONFIG.expand("{var1} and {var2}") == {
+    result = CONFIG.expand("{var1} and {var2}")
+    expected = {
         "var1": "value1",
         "var2": None,
     }
+    check.equal(result, expected, "Expand should handle both existing and non-existing variables")
 
 
 def test_config_expand_variables_handles_recursive_variable_resolution():
     CONFIG["var1"] = "{var2}"
     CONFIG["var2"] = "value2"
 
-    assert CONFIG.expand("{var1}") == {
+    result = CONFIG.expand("{var1}")
+    expected = {
         "var1": "value2",
     }
+    check.equal(result, expected, "Expand should resolve recursive variable references")
 
 
 def test_config_expand_with_custom_variable_handling():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,7 +58,7 @@ def test_config_can_load_an_empty_config():
         CONFIG.load(temp_cucurc.name)
 
 
-def test_confi_validate_defined_variables():
+def test_config_validate_defined_variables():
     for variable in CONFIG.defined_variables:
         print(variable)
 

--- a/tests/test_teestream.py
+++ b/tests/test_teestream.py
@@ -1,0 +1,116 @@
+import tempfile
+from io import StringIO
+
+from cucu.utils import TeeStream
+
+
+def test_teestream_writes_to_file_and_buffer():
+    """Test that TeeStream writes to both file and internal buffer."""
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp_file:
+        tee = TeeStream(temp_file)
+
+        test_data = "Hello, World!"
+        tee.write(test_data)
+        tee.flush()
+
+        # Check that data was written to file
+        temp_file.seek(0)
+        file_content = temp_file.read()
+        assert file_content == test_data
+
+        # Check that data was captured in buffer
+        buffer_content = tee.getvalue()
+        assert buffer_content == test_data
+
+
+def test_teestream_multiple_writes():
+    """Test that TeeStream handles multiple writes correctly."""
+    file_stream = StringIO()
+    tee = TeeStream(file_stream)
+
+    tee.write("Line 1\n")
+    tee.write("Line 2\n")
+    tee.write("Line 3\n")
+
+    expected = "Line 1\nLine 2\nLine 3\n"
+
+    # Check file content
+    assert file_stream.getvalue() == expected
+
+    # Check buffer content
+    assert tee.getvalue() == expected
+
+
+def test_teestream_read_alias():
+    """Test that read() is an alias for getvalue()."""
+    file_stream = StringIO()
+    tee = TeeStream(file_stream)
+
+    test_data = "Test data"
+    tee.write(test_data)
+
+    assert tee.read() == test_data
+    assert tee.getvalue() == test_data
+
+
+def test_teestream_clear_buffer():
+    """Test that clear() resets the internal buffer."""
+    file_stream = StringIO()
+    tee = TeeStream(file_stream)
+
+    tee.write("Initial data")
+    assert tee.getvalue() == "Initial data"
+
+    tee.clear()
+    assert tee.getvalue() == ""
+
+    # File content should still be there
+    assert file_stream.getvalue() == "Initial data"
+
+    # New writes should work normally
+    tee.write("New data")
+    assert tee.getvalue() == "New data"
+    assert file_stream.getvalue() == "Initial dataNew data"
+
+
+def test_teestream_empty_writes():
+    """Test that TeeStream handles empty writes."""
+    file_stream = StringIO()
+    tee = TeeStream(file_stream)
+
+    tee.write("")
+    assert tee.getvalue() == ""
+    assert file_stream.getvalue() == ""
+
+
+def test_teestream_flush():
+    """Test that flush() calls flush on the file stream."""
+    file_stream = StringIO()
+    tee = TeeStream(file_stream)
+
+    tee.write("Test")
+    tee.flush()  # Should not raise any exceptions
+
+    assert tee.getvalue() == "Test"
+    assert file_stream.getvalue() == "Test"
+
+
+def test_teestream_with_real_file():
+    """Test TeeStream with an actual file object."""
+    with tempfile.NamedTemporaryFile(mode="w+", delete=True) as temp_file:
+        tee = TeeStream(temp_file)
+
+        lines = ["First line\n", "Second line\n", "Third line\n"]
+        for line in lines:
+            tee.write(line)
+
+        tee.flush()
+
+        # Read from file
+        temp_file.seek(0)
+        file_lines = temp_file.readlines()
+        assert file_lines == lines
+
+        # Check buffer
+        expected_buffer = "".join(lines)
+        assert tee.getvalue() == expected_buffer

--- a/tests/test_teestream.py
+++ b/tests/test_teestream.py
@@ -14,8 +14,14 @@ def test_teestream_writes_to_file_and_buffer():
     tee.write(test_data)
 
     # Check both outputs with soft assertions to see all results
-    check.equal(file_stream.getvalue(), test_data, "File stream should contain the written data")
-    check.equal(tee.getvalue(), test_data, "Buffer should contain the written data")
+    check.equal(
+        file_stream.getvalue(),
+        test_data,
+        "File stream should contain the written data",
+    )
+    check.equal(
+        tee.getvalue(), test_data, "Buffer should contain the written data"
+    )
 
 
 def test_teestream_multiple_writes():
@@ -30,7 +36,11 @@ def test_teestream_multiple_writes():
     expected = "Line 1\nLine 2\nLine 3\n"
 
     # Check both outputs with soft assertions
-    check.equal(file_stream.getvalue(), expected, "File stream should contain all writes")
+    check.equal(
+        file_stream.getvalue(),
+        expected,
+        "File stream should contain all writes",
+    )
     check.equal(tee.getvalue(), expected, "Buffer should contain all writes")
 
 
@@ -48,6 +58,12 @@ def test_teestream_content_consistency():
     file_content = file_stream.getvalue()
     buffer_content = tee.getvalue()
     expected = "First chunk Second chunk Third chunk"
-    
-    check.equal(file_content, buffer_content, "File and buffer content should be identical")
-    check.equal(file_content, expected, "Content should match expected concatenation")
+
+    check.equal(
+        file_content,
+        buffer_content,
+        "File and buffer content should be identical",
+    )
+    check.equal(
+        file_content, expected, "Content should match expected concatenation"
+    )

--- a/tests/test_teestream.py
+++ b/tests/test_teestream.py
@@ -1,30 +1,25 @@
-import tempfile
 from io import StringIO
+
+import pytest_check as check
 
 from cucu.utils import TeeStream
 
 
 def test_teestream_writes_to_file_and_buffer():
-    """Test that TeeStream writes to both file and internal buffer."""
-    with tempfile.NamedTemporaryFile(mode="w+", delete=True) as temp_file:
-        tee = TeeStream(temp_file)
+    """Test that TeeStream writes to both file and internal buffer simultaneously."""
+    file_stream = StringIO()
+    tee = TeeStream(file_stream)
 
-        test_data = "Hello, World!"
-        tee.write(test_data)
-        tee.flush()
+    test_data = "Hello, World!"
+    tee.write(test_data)
 
-        # Check that data was written to file
-        temp_file.seek(0)
-        file_content = temp_file.read()
-        assert file_content == test_data
-
-        # Check that data was captured in buffer
-        buffer_content = tee.getvalue()
-        assert buffer_content == test_data
+    # Check both outputs with soft assertions to see all results
+    check.equal(file_stream.getvalue(), test_data, "File stream should contain the written data")
+    check.equal(tee.getvalue(), test_data, "Buffer should contain the written data")
 
 
 def test_teestream_multiple_writes():
-    """Test that TeeStream handles multiple writes correctly."""
+    """Test that multiple sequential writes work correctly."""
     file_stream = StringIO()
     tee = TeeStream(file_stream)
 
@@ -34,83 +29,25 @@ def test_teestream_multiple_writes():
 
     expected = "Line 1\nLine 2\nLine 3\n"
 
-    # Check file content
-    assert file_stream.getvalue() == expected
-
-    # Check buffer content
-    assert tee.getvalue() == expected
+    # Check both outputs with soft assertions
+    check.equal(file_stream.getvalue(), expected, "File stream should contain all writes")
+    check.equal(tee.getvalue(), expected, "Buffer should contain all writes")
 
 
-def test_teestream_read_alias():
-    """Test that read() is an alias for getvalue()."""
+def test_teestream_content_consistency():
+    """Test that both file stream and buffer contain identical content."""
     file_stream = StringIO()
     tee = TeeStream(file_stream)
 
-    test_data = "Test data"
-    tee.write(test_data)
+    # Write multiple chunks of data
+    chunks = ["First chunk", " Second chunk", " Third chunk"]
+    for chunk in chunks:
+        tee.write(chunk)
 
-    assert tee.read() == test_data
-    assert tee.getvalue() == test_data
-
-
-def test_teestream_clear_buffer():
-    """Test that clear() resets the internal buffer."""
-    file_stream = StringIO()
-    tee = TeeStream(file_stream)
-
-    tee.write("Initial data")
-    assert tee.getvalue() == "Initial data"
-
-    tee.clear()
-    assert tee.getvalue() == ""
-
-    # File content should still be there
-    assert file_stream.getvalue() == "Initial data"
-
-    # New writes should work normally
-    tee.write("New data")
-    assert tee.getvalue() == "New data"
-    assert file_stream.getvalue() == "Initial dataNew data"
-
-
-def test_teestream_empty_writes():
-    """Test that TeeStream handles empty writes."""
-    file_stream = StringIO()
-    tee = TeeStream(file_stream)
-
-    tee.write("")
-    assert tee.getvalue() == ""
-    assert file_stream.getvalue() == ""
-
-
-def test_teestream_flush():
-    """Test that flush() calls flush on the file stream."""
-    file_stream = StringIO()
-    tee = TeeStream(file_stream)
-
-    tee.write("Test")
-    tee.flush()  # Should not raise any exceptions
-
-    assert tee.getvalue() == "Test"
-    assert file_stream.getvalue() == "Test"
-
-
-def test_teestream_with_real_file():
-    """Test TeeStream with an actual file object."""
-    with tempfile.NamedTemporaryFile(mode="w+", delete=True) as temp_file:
-        tee = TeeStream(temp_file)
-
-        lines = ["First line\n", "Second line\n", "Third line\n"]
-        for line in lines:
-            tee.write(line)
-
-        tee.flush()
-
-        # Read from file
-        temp_file.seek(0)
-        file_lines = temp_file.readlines()
-        assert file_lines == lines
-
-        # Check buffer
-        expected_buffer = "".join(lines)
-        assert tee.getvalue() == expected_buffer
+    # Verify both outputs are identical and contain expected content
+    file_content = file_stream.getvalue()
+    buffer_content = tee.getvalue()
+    expected = "First chunk Second chunk Third chunk"
+    
+    check.equal(file_content, buffer_content, "File and buffer content should be identical")
+    check.equal(file_content, expected, "Content should match expected concatenation")

--- a/tests/test_teestream.py
+++ b/tests/test_teestream.py
@@ -6,7 +6,7 @@ from cucu.utils import TeeStream
 
 def test_teestream_writes_to_file_and_buffer():
     """Test that TeeStream writes to both file and internal buffer."""
-    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp_file:
+    with tempfile.NamedTemporaryFile(mode="w+", delete=True) as temp_file:
         tee = TeeStream(temp_file)
 
         test_data = "Hello, World!"

--- a/uv.lock
+++ b/uv.lock
@@ -282,6 +282,7 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-check" },
     { name = "ruff" },
 ]
 
@@ -312,6 +313,7 @@ requires-dist = [
 dev = [
     { name = "pre-commit", specifier = ">=3.8.0" },
     { name = "pytest", specifier = "~=8.4.0" },
+    { name = "pytest-check", specifier = ">=2.5.3" },
     { name = "ruff", specifier = ">=0.6.4" },
 ]
 
@@ -729,6 +731,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
+]
+
+[[package]]
+name = "pytest-check"
+version = "2.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/f8/58aa6cf0af7bc261c4606c28582258e76cec398a7d8bdc2e82de51039f84/pytest_check-2.5.3.tar.gz", hash = "sha256:2357d7df77c395d30c0c4957724fdfce1a75ea8bc9eb2308c0ffe56f62ac70ca", size = 27422, upload-time = "2025-04-04T01:44:43.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/29/d3fbd683c50aeb93d79377c904179c82f01f9f656299deb89328ab85b0a2/pytest_check-2.5.3-py3-none-any.whl", hash = "sha256:354685dfa63e714a20aa62b61c4d30d5acfa30891319df9046f59af653c3b9ba", size = 15998, upload-time = "2025-04-04T01:44:41.951Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## 1.2.5
- Add - CONFIG now can save multiple snapshots in a stack
- Add - features, scenarios and steps - add various metadata
- Add - pytest-check for mulitple asserts
- Add - steps - add browser info and screenshot info
- Add - steps - add debug log and browser log
- Add - steps - add section level, seq and parent_seq info
- Change - extract generate_short_id to utils
- Change - rename .start_timestamp => to .start_at
- Change - use pathlib for paths
- Chore - CI - fix results to not be deleted by pytest
- Chore - makefile - make fix more like make lint