### PR TITLE
QE-17932 Step to save current browser URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.7
+- Add - steps - add step to save the current browser URL to a variable
+
 ## 1.2.6
 - Fix - core run - allow config to be changed by environment.py import
 

--- a/features/browser/browser_window_managemenet.feature
+++ b/features/browser/browser_window_managemenet.feature
@@ -80,3 +80,15 @@ Feature: Browser window management
       """
       # so the next test doesn't end up with a silly tiny browser window
       And I close the current browser
+
+  Scenario: User can save the current browser url to a variable
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+     When I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/buttons.html"
+     Then I should see the browser title is "Buttons!"
+
+     When I save the current browser url to the variable "CURRENT_URL"
+      And I navigate to the url "http://{HOST_ADDRESS}:{PORT}/inputs.html"
+     Then I should see the browser title is "Inputs!"
+
+     When I navigate to the url "{CURRENT_URL}"
+     Then I should see the browser title is "Buttons!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.2.6"
+version = "1.2.7"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }

--- a/src/cucu/steps/browser_steps.py
+++ b/src/cucu/steps/browser_steps.py
@@ -163,6 +163,16 @@ def navigate_to_the_url(ctx, url):
     ctx.browser.navigate(url)
 
 
+@step('I save the current browser url to the variable "{variable}"')
+def save_current_browser_url_to_variable(ctx, variable):
+    ctx.check_browser_initialized()
+    current_url = ctx.browser.get_current_url()
+    config.CONFIG[variable] = current_url
+    logger.debug(
+        f"saved current browser url {current_url} to variable {variable}"
+    )
+
+
 @step("I switch to the previous browser")
 def switch_to_previous_browser(ctx):
     browser_index = ctx.browsers.index(ctx.browser)

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.2.6"
+version = "1.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
We lack the ability to get the current browser tab's URL

Issue Number: https://dominodatalab.atlassian.net/browse/QE-17932

## What is the new behavior?
Add a step to get the URL and save to a variable

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
