### PR TITLE
Fix - avoid unfocus event in after_step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.8
+- Fix - avoid unfocus event in after_step
+
 ## 1.2.7
 - Add - steps - add step to save the current browser URL to a variable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.2.7"
+version = "1.2.8"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = { text = "The Clear BSD License" }

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -1,7 +1,7 @@
+import datetime
 import json
 import sys
 import traceback
-from datetime import datetime
 from functools import partial
 from pathlib import Path
 
@@ -97,7 +97,7 @@ def before_scenario(ctx, scenario):
 
     # reset the step timer dictionary
     ctx.step_timers = {}
-    scenario.start_at = datetime.now().isoformat()[:-3]
+    scenario.start_at = datetime.datetime.now().isoformat()[:-3]
 
     if config.CONFIG["CUCU_RESULTS_DIR"] is not None:
         ctx.scenario_dir = ctx.feature_dir / ellipsize_filename(scenario.name)
@@ -199,7 +199,7 @@ def after_scenario(ctx, scenario):
         yaml.safe_load(CONFIG.to_yaml_without_secrets())
     )
 
-    scenario.end_at = datetime.now().isoformat()[:-3]
+    scenario.end_at = datetime.datetime.now().isoformat()[:-3]
 
 
 def download_mht_data(ctx):
@@ -232,7 +232,7 @@ def download_browser_log(ctx):
 
 def before_step(ctx, step):
     step.step_run_id = generate_short_id()
-    step.start_at = datetime.now().isoformat()[:-3]
+    step.start_at = datetime.datetime.now().isoformat()[:-3]
 
     sys.stdout.captured()
     sys.stderr.captured()
@@ -266,11 +266,11 @@ def after_step(ctx, step):
     else:
         step.debug_output = ""
 
-    step.end_at = datetime.now().isoformat()[:-3]
+    step.end_at = datetime.datetime.now().isoformat()[:-3]
 
     # calculate duration from ISO timestamps
-    start_at = datetime.fromisoformat(step.start_at)
-    end_at = datetime.fromisoformat(step.end_at)
+    start_at = datetime.datetime.fromisoformat(step.start_at)
+    end_at = datetime.datetime.fromisoformat(step.end_at)
     ctx.previous_step_duration = (end_at - start_at).total_seconds()
 
     # when set this means we're running in parallel mode using --workers and

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -331,12 +331,13 @@ def after_step(ctx, step):
         step.browser_logs = "\n".join(browser_logs)
 
         tab_info = ctx.browser.get_tab_info()
-        all_tabs = ctx.browser.get_all_tabs_info()
 
         browser_info = {
-            "current_tab_index": tab_info["index"],
-            "all_tabs": all_tabs,
+            "tab_count": tab_info["tab_count"],
+            "tab_number": tab_info["index"] + 1,
+            "tab_title": tab_info["title"],
+            "tab_url": tab_info["url"],
             "browser_type": ctx.browser.driver.name,
         }
 
-    step.browser_info = json.dumps(browser_info)
+    step.browser_info = browser_info

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -254,7 +254,7 @@ toml = [
 
 [[package]]
 name = "cucu"
-version = "1.2.7"
+version = "1.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1.2.7 introduced an issue by recording all tab info which requires selenium to cycle through tabs and that causes an unfocus event

Issue Number: https://dominodatalab.atlassian.net/browse/QE-18205

## What is the new behavior?

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
