### PR TITLE
QE-19118 more id uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 
 # 1.4.17
 - Change - more id uniquness to use 12 digits
+- Change - remove lazy load report images
 
 # 1.4.16
 - Change - step decorator to preserve all errors as test fails for behave 1.3.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.4.17
+- Change - more id uniquness to use 12 digits
+
 # 1.4.16
 - Change - step decorator to preserve all errors as test fails for behave 1.3.x
   - auto-convert exceptions to AssertionError by default, and log it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.16"
+version = "1.4.17"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/formatter/rundb.py
+++ b/src/cucu/formatter/rundb.py
@@ -167,9 +167,7 @@ class RundbFormatter(Formatter):
         """cucu specific step insertion method used to add steps here and dynamically"""
         next_index = index if index != -1 else len(self.this_steps)
         step_run_id_seed = f"{self.this_scenario.scenario_run_id}_{next_index}_{time.perf_counter()}"
-        step.step_run_id = generate_short_id(
-            step_run_id_seed, length=10
-        )  # up to 10 characters to give two orders of magnitude less chance of collision
+        step.step_run_id = generate_short_id(step_run_id_seed)
         self.this_steps.insert(next_index, step)
         start_step_record(step, self.this_scenario.scenario_run_id)
 

--- a/src/cucu/reporter/templates/scenario.html
+++ b/src/cucu/reporter/templates/scenario.html
@@ -163,7 +163,7 @@
                     <summary style="color: dimgray;">images ({{ step['screenshots']|length }} images)</summary>
                     <div style="margin: 10px 0 0 0;">
                         {% for image in step['screenshots'] %}
-                            <img loading="lazy" class="mx-auto d-block img-fluid shadow bg-white rounded" id="{{ image['html_id'] }}" style="margin-bottom:15px" alt="{{ escape(image['label']) }}" title="{{ escape(image['label']) }}" src="{{ image['html_src'] }}"></img>
+                            <img class="mx-auto d-block img-fluid shadow bg-white rounded" id="{{ image['html_id'] }}" style="margin-bottom:15px" alt="{{ escape(image['label']) }}" title="{{ escape(image['label']) }}" src="{{ image['html_src'] }}"></img>
                             {% if image['highlight'] %}
                             <div class="step-image-highlight" id="{{ image['html_id']}}-highlight" height-ratio="{{ image['highlight']['height_ratio'] }}" width-ratio="{{ image['highlight']['width_ratio'] }}" top-ratio="{{ image['highlight']['top_ratio'] }}" left-ratio="{{ image['highlight']['left_ratio'] }}"></div>
                             {% endif %}
@@ -203,11 +203,6 @@
         for (var index=0; index < expandables.length; index++) {
             $(expandables[index]).removeClass('hide')
             $(expandables[index]).addClass('show')
-        }
-
-        // For Firefox, force eager loading of images
-        if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-            document.querySelectorAll('img[loading="lazy"]').forEach(img => img.setAttribute('loading', 'eager'));
         }
 
         // necessary to make sure we jump to the anchored step as the page loads

--- a/src/cucu/utils.py
+++ b/src/cucu/utils.py
@@ -49,7 +49,7 @@ class StopRetryException(Exception):
     pass
 
 
-def generate_short_id(seed=None, length=7):
+def generate_short_id(seed=None, length=12):
     """
     Generate a short character ID based on seed (defaults to current performance counter).
     """

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.16"
+version = "1.4.17"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [x] Other... Please describe:

**Stronger default IDs for run records (`generate_short_id` length 12) and HTML report screenshot loading (no `loading="lazy"`).**

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- `generate_short_id` defaulted to 7 characters; step run IDs in the rundb formatter used 10.
- The scenario HTML report marked step screenshots with `loading="lazy"` and included a Firefox-only script to force eager loading.

Issue Number: https://dominodatalab.atlassian.net/browse/QE-19118

## What is the new behavior?

- Default short ID length is **12** for all callers using the default (run, worker, feature, scenario, and step IDs). Step IDs no longer use a separate 10-character length.
- Scenario report screenshots load with the page (lazy loading and the Firefox workaround removed).
- Version **1.4.17** and changelog entry under `# 1.4.17`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- Primary touchpoints for review: `src/cucu/utils.py` (`generate_short_id`), `src/cucu/formatter/rundb.py`, `src/cucu/reporter/templates/scenario.html`.
- **Testing:** Not described in-repo; please add a note in a follow-up comment if you ran a specific manual pass (e.g. generated report in Chrome/Firefox).
