### PR TITLE
QE-17116 feat: nested iframe search and open shadow DOM helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 1.5.0
+# 1.4.18
 - Add - nested iframe search (`switch_to_frame_path`, `search_in_all_frames_nested`, `search_in_all_frames_nested_and_deep`)
 - Add - open shadow DOM CSS helpers (`deep_query_selector_first`, `deep_query_selector_all`) and opt-in `Selenium.css_find_elements_nested` / `css_find_elements_deep`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 # 1.4.18
 - Add - nested iframe search (`switch_to_frame_path`, `search_in_all_frames_nested`, `search_in_all_frames_nested_and_deep`)
 - Add - open shadow DOM CSS helpers (`deep_query_selector_first`, `deep_query_selector_all`) and opt-in `Selenium.css_find_elements_nested` / `css_find_elements_deep`
+- Change - `search_in_all_frames` defaults to nested iframe BFS; pass `include_nested_frames=False` for the previous top-level-only walk; `max_depth` applies when nested mode is on
+- Change - `search_in_all_frames_nested` is now a thin wrapper around `search_in_all_frames`
 
 # 1.4.17
 - Change - more id uniquness to use 12 digits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.5.0
+- Add - nested iframe search (`switch_to_frame_path`, `search_in_all_frames_nested`, `search_in_all_frames_nested_and_deep`)
+- Add - open shadow DOM CSS helpers (`deep_query_selector_first`, `deep_query_selector_all`) and opt-in `Selenium.css_find_elements_nested` / `css_find_elements_deep`
+
 # 1.4.17
 - Change - more id uniquness to use 12 digits
 - Change - remove lazy load report images

--- a/README.md
+++ b/README.md
@@ -269,13 +269,15 @@ Notes:
 
 ## Nested iframes and open shadow DOM
 
-Built-in fuzzy matching and `css_find_elements` only walk the top document plus
-**one** level of child `iframe` contexts. For deeper iframe trees, use
-`cucu.browser.frames.search_in_all_frames_nested` (breadth-first by iframe index
-path from default content, with a `max_depth` guard). Helpers
-`switch_to_frame_path` and `search_in_all_frames_nested_and_deep` live in the
-same module. Like `search_in_all_frames`, nested search **leaves the session in
-the last frame that was searched** when a match is found.
+`cucu.browser.frames.search_in_all_frames` walks the current context, then
+default content, then **nested** `iframe` trees breadth-first by index path
+from default content (with a `max_depth` guard). Pass
+`include_nested_frames=False` to restore the previous behavior of only the
+default document plus **top-level** iframes. Helpers `switch_to_frame_path` and
+`search_in_all_frames_nested_and_deep` live in the same module; the legacy name
+`search_in_all_frames_nested` is an alias for nested mode. Like all frame search
+helpers here, search **leaves the session in the last frame that was searched**
+when a match is found.
 
 Selenium’s normal CSS queries do not enter **open** `shadowRoot` trees. For
 that, use `cucu.browser.shadow.deep_query_selector_first` /

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ to drive various underlying tools/frameworks to create real world testing scenar
 - [Extending Cucu](#extending-cucu)
   - [Fuzzy matching](#fuzzy-matching)
     - [Relevance Scoring (Ordering)](#relevance-scoring-ordering)
+  - [Nested iframes and open shadow DOM](#nested-iframes-and-open-shadow-dom)
   - [Custom steps](#custom-steps)
     - [Passing exceptions through](#passing-exceptions-through)
   - [Before / After hooks](#before--after-hooks)
@@ -265,6 +266,23 @@ When fuzzy matching yields multiple candidates, cucu orders results by a case-se
 Notes:
 - All matching is case-sensitive to mirror how selectors like `:contains` and custom `:has_text` behave.
 - The scoring is applied after deduplication by element identity.
+
+## Nested iframes and open shadow DOM
+
+Built-in fuzzy matching and `css_find_elements` only walk the top document plus
+**one** level of child `iframe` contexts. For deeper iframe trees, use
+`cucu.browser.frames.search_in_all_frames_nested` (breadth-first by iframe index
+path from default content, with a `max_depth` guard). Helpers
+`switch_to_frame_path` and `search_in_all_frames_nested_and_deep` live in the
+same module. Like `search_in_all_frames`, nested search **leaves the session in
+the last frame that was searched** when a match is found.
+
+Selenium’s normal CSS queries do not enter **open** `shadowRoot` trees. For
+that, use `cucu.browser.shadow.deep_query_selector_first` /
+`deep_query_selector_all` with the current `WebDriver`, or opt into
+`Selenium.css_find_elements_deep` / `css_find_elements_nested` on the cucu
+browser object. Closed shadow roots and cross-origin nested documents are still
+out of reach from the parent page.
 
 ## Custom steps
 It's easy to create custom steps, for example:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.17"
+version = "1.5.0"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.5.0"
+version = "1.4.18"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/browser/frames.py
+++ b/src/cucu/browser/frames.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 from cucu.browser.core import Browser
 
 
@@ -104,3 +106,134 @@ def try_in_frames_until_success(browser: Browser, function_to_run) -> None:
                         f"{function_to_run.__name__} failed in all frames"
                     )
             return
+
+
+def switch_to_frame_path(browser, path: tuple[int, ...]) -> None:
+    """
+    Switch to default content, then for each index resolve
+    document.querySelectorAll("iframe") in the current document and
+    switch_to.frame(iframe[index]). Re-queries iframes from the top on each
+    call to reduce stale element issues.
+
+    parameters:
+      browser - the cucu.browser.Browser object
+      path      - tuple of iframe indices from default content
+    """
+    browser.switch_to_default_frame()
+    for idx in path:
+        frames = browser.execute('return document.querySelectorAll("iframe");')
+        browser.switch_to_frame(frames[idx])
+
+
+def search_in_all_frames_nested(
+    browser, search_function, *, max_depth: int = 15
+):
+    """
+    Like search_in_all_frames, but descends into nested iframes breadth-first
+    by index path from default content (up to max_depth levels).
+
+    Warning: This leaves the browser in whatever frame was last searched so
+    callers remain in that frame.
+
+    parameters:
+      browser         - the cucu.browser.Browser object
+      search_function - function to run in each candidate frame (no arguments)
+      max_depth       - maximum iframe depth (number of indices in a path)
+
+    returns:
+      The first truthy value returned by search_function, or the last falsy
+      result if nothing matched (same convention as search_in_all_frames).
+    """
+    result = search_function()
+    if result:
+        return result
+
+    browser.switch_to_default_frame()
+    result = search_function()
+    if result:
+        return result
+
+    queue = deque()
+    frames = browser.execute('return document.querySelectorAll("iframe");')
+    for i in range(len(frames)):
+        if len((i,)) <= max_depth:
+            queue.append((i,))
+
+    while queue:
+        path = queue.popleft()
+        switch_to_frame_path(browser, path)
+        result = search_function()
+        if result:
+            return result
+
+        inner = browser.execute('return document.querySelectorAll("iframe");')
+        for j in range(len(inner)):
+            next_path = path + (j,)
+            if len(next_path) <= max_depth:
+                queue.append(next_path)
+
+    return result
+
+
+def search_in_all_frames_nested_and_deep(
+    browser, selector: str, *, max_depth: int = 15
+):
+    """
+    For each nested frame (BFS, same ordering as search_in_all_frames_nested),
+    run deep_query_selector_first in that frame's document.
+
+    Requires a Selenium-backed browser with a ``driver`` attribute.
+
+    Warning: Leaves the browser focused on the frame where the first match
+    occurred (or default content if the match was in the light DOM there).
+
+    parameters:
+      browser   - Browser with ``.driver`` (cucu Selenium)
+      selector  - CSS selector passed to deep_query_selector_first
+      max_depth - passed through to the nested iframe walk
+
+    returns:
+      On success: ``(element, path)`` where ``path`` is an iframe index tuple
+      from default content, ``()`` when the match is in default content after
+      switching to it, or ``None`` when the match is in the original browsing
+      context before that switch. On failure: ``(None, None)``.
+    """
+    from cucu.browser.shadow import deep_query_selector_first
+
+    try:
+        driver = browser.driver
+    except AttributeError as exc:
+        raise TypeError(
+            "search_in_all_frames_nested_and_deep requires a Selenium browser "
+            "with a .driver attribute"
+        ) from exc
+
+    element = deep_query_selector_first(driver, selector)
+    if element:
+        return (element, None)
+
+    browser.switch_to_default_frame()
+    element = deep_query_selector_first(driver, selector)
+    if element:
+        return (element, ())
+
+    queue = deque()
+    frames = browser.execute('return document.querySelectorAll("iframe");')
+    for i in range(len(frames)):
+        if len((i,)) <= max_depth:
+            queue.append((i,))
+
+    while queue:
+        path = queue.popleft()
+        switch_to_frame_path(browser, path)
+        element = deep_query_selector_first(driver, selector)
+        if element:
+            return (element, path)
+
+        inner = browser.execute('return document.querySelectorAll("iframe");')
+        for j in range(len(inner)):
+            next_path = path + (j,)
+            if len(next_path) <= max_depth:
+                queue.append(next_path)
+
+    return (None, None)

--- a/src/cucu/browser/frames.py
+++ b/src/cucu/browser/frames.py
@@ -3,7 +3,13 @@ from collections import deque
 from cucu.browser.core import Browser
 
 
-def search_in_all_frames(browser, search_function):
+def search_in_all_frames(
+    browser,
+    search_function,
+    *,
+    include_nested_frames: bool = True,
+    max_depth: int = 15,
+):
     """
     search all frames on the page for an element
 
@@ -11,32 +17,59 @@ def search_in_all_frames(browser, search_function):
     users of this method are in that frame.
 
     parameters:
-      browser           - the cucu.browser.Browser object
-      search_function   - function to search for the element (within a frame)
+      browser               - the cucu.browser.Browser object
+      search_function       - function to search for the element (within a frame)
+      include_nested_frames - when True (default), breadth-first search into nested
+                              iframes by index path up to max_depth; when False,
+                              only the default document and top-level iframes
+      max_depth             - maximum iframe path length when include_nested_frames
+                              is True (ignored otherwise)
     returns:
         the WebElement that matches (if found)
     """
-    # check whatever frame we're currently in
     result = search_function()
 
     if not result:
-        # we might have not been in the default frame so check again
         browser.switch_to_default_frame()
 
         result = search_function()
         if result:
             return result
 
-        frames = browser.execute('return document.querySelectorAll("iframe");')
-        for frame in frames:
-            # need to be in the default frame in order to switch to a child
-            # frame w/o getting a stale element exception
-            browser.switch_to_default_frame()
-            browser.switch_to_frame(frame)
-            result = search_function()
+        if include_nested_frames:
+            queue = deque()
+            frames = browser.execute(
+                'return document.querySelectorAll("iframe");'
+            )
+            for i in range(len(frames)):
+                if len((i,)) <= max_depth:
+                    queue.append((i,))
 
-            if result:
-                return result
+            while queue:
+                path = queue.popleft()
+                switch_to_frame_path(browser, path)
+                result = search_function()
+                if result:
+                    return result
+
+                inner = browser.execute(
+                    'return document.querySelectorAll("iframe");'
+                )
+                for j in range(len(inner)):
+                    next_path = path + (j,)
+                    if len(next_path) <= max_depth:
+                        queue.append(next_path)
+        else:
+            frames = browser.execute(
+                'return document.querySelectorAll("iframe");'
+            )
+            for frame in frames:
+                browser.switch_to_default_frame()
+                browser.switch_to_frame(frame)
+                result = search_function()
+
+                if result:
+                    return result
 
     return result
 
@@ -129,57 +162,23 @@ def search_in_all_frames_nested(
     browser, search_function, *, max_depth: int = 15
 ):
     """
-    Like search_in_all_frames, but descends into nested iframes breadth-first
-    by index path from default content (up to max_depth levels).
-
-    Warning: This leaves the browser in whatever frame was last searched so
-    callers remain in that frame.
-
-    parameters:
-      browser         - the cucu.browser.Browser object
-      search_function - function to run in each candidate frame (no arguments)
-      max_depth       - maximum iframe depth (number of indices in a path)
-
-    returns:
-      The first truthy value returned by search_function, or the last falsy
-      result if nothing matched (same convention as search_in_all_frames).
+    Equivalent to ``search_in_all_frames(..., include_nested_frames=True,
+    max_depth=max_depth)``.
     """
-    result = search_function()
-    if result:
-        return result
-
-    browser.switch_to_default_frame()
-    result = search_function()
-    if result:
-        return result
-
-    queue = deque()
-    frames = browser.execute('return document.querySelectorAll("iframe");')
-    for i in range(len(frames)):
-        if len((i,)) <= max_depth:
-            queue.append((i,))
-
-    while queue:
-        path = queue.popleft()
-        switch_to_frame_path(browser, path)
-        result = search_function()
-        if result:
-            return result
-
-        inner = browser.execute('return document.querySelectorAll("iframe");')
-        for j in range(len(inner)):
-            next_path = path + (j,)
-            if len(next_path) <= max_depth:
-                queue.append(next_path)
-
-    return result
+    return search_in_all_frames(
+        browser,
+        search_function,
+        include_nested_frames=True,
+        max_depth=max_depth,
+    )
 
 
 def search_in_all_frames_nested_and_deep(
     browser, selector: str, *, max_depth: int = 15
 ):
     """
-    For each nested frame (BFS, same ordering as search_in_all_frames_nested),
+    For each nested frame (BFS, same ordering as search_in_all_frames with
+    nested iframes enabled),
     run deep_query_selector_first in that frame's document.
 
     Requires a Selenium-backed browser with a ``driver`` attribute.

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -16,10 +16,7 @@ from selenium.webdriver.remote.command import Command
 
 from cucu import config, edgedriver_autoinstaller, logger
 from cucu.browser.core import Browser
-from cucu.browser.frames import (
-    search_in_all_frames,
-    search_in_all_frames_nested,
-)
+from cucu.browser.frames import search_in_all_frames
 from cucu.browser.shadow import deep_query_selector_all
 
 # suppress warning caused by selenium_keep_alive taking an extra http connection
@@ -359,8 +356,11 @@ class Selenium(Browser):
 
             return list(filter(visible, elements))
 
-        return search_in_all_frames_nested(
-            self, find_elements_in_frame, max_depth=max_depth
+        return search_in_all_frames(
+            self,
+            find_elements_in_frame,
+            include_nested_frames=True,
+            max_depth=max_depth,
         )
 
     def css_find_elements_deep(self, selector, *, max_depth: int = 15):
@@ -372,8 +372,11 @@ class Selenium(Browser):
 
             return list(filter(visible, elements))
 
-        return search_in_all_frames_nested(
-            self, find_in_frame, max_depth=max_depth
+        return search_in_all_frames(
+            self,
+            find_in_frame,
+            include_nested_frames=True,
+            max_depth=max_depth,
         )
 
     def execute(self, javascript, *args):

--- a/src/cucu/browser/selenium.py
+++ b/src/cucu/browser/selenium.py
@@ -16,7 +16,11 @@ from selenium.webdriver.remote.command import Command
 
 from cucu import config, edgedriver_autoinstaller, logger
 from cucu.browser.core import Browser
-from cucu.browser.frames import search_in_all_frames
+from cucu.browser.frames import (
+    search_in_all_frames,
+    search_in_all_frames_nested,
+)
+from cucu.browser.shadow import deep_query_selector_all
 
 # suppress warning caused by selenium_keep_alive taking an extra http connection
 logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
@@ -345,6 +349,32 @@ class Selenium(Browser):
         elements = search_in_all_frames(self, find_elements_in_frame)
 
         return elements
+
+    def css_find_elements_nested(self, selector, *, max_depth: int = 15):
+        def find_elements_in_frame():
+            elements = self.driver.find_elements(By.CSS_SELECTOR, selector)
+
+            def visible(element):
+                return element.is_displayed()
+
+            return list(filter(visible, elements))
+
+        return search_in_all_frames_nested(
+            self, find_elements_in_frame, max_depth=max_depth
+        )
+
+    def css_find_elements_deep(self, selector, *, max_depth: int = 15):
+        def find_in_frame():
+            elements = deep_query_selector_all(self.driver, selector)
+
+            def visible(element):
+                return element.is_displayed()
+
+            return list(filter(visible, elements))
+
+        return search_in_all_frames_nested(
+            self, find_in_frame, max_depth=max_depth
+        )
 
     def execute(self, javascript, *args):
         return self.driver.execute_script(javascript, *args)

--- a/src/cucu/browser/shadow.py
+++ b/src/cucu/browser/shadow.py
@@ -1,0 +1,93 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+
+_DEEP_QUERY_FIRST_JS = """
+var sel = arguments[0];
+function cucuWalkFirst(n) {
+    if (!n) {
+        return null;
+    }
+    if (n.nodeType === 1 && n.matches && n.matches(sel)) {
+        return n;
+    }
+    var ch = n.children;
+    if (ch) {
+        for (var i = 0; i < ch.length; i++) {
+            var r = cucuWalkFirst(ch[i]);
+            if (r) {
+                return r;
+            }
+        }
+    }
+    if (n.nodeType === 1 && n.shadowRoot) {
+        var sh = n.shadowRoot.children;
+        for (var j = 0; j < sh.length; j++) {
+            var r2 = cucuWalkFirst(sh[j]);
+            if (r2) {
+                return r2;
+            }
+        }
+    }
+    return null;
+}
+return cucuWalkFirst(document.documentElement);
+"""
+
+_DEEP_QUERY_ALL_JS = """
+var sel = arguments[0];
+var acc = [];
+function cucuWalkAll(n) {
+    if (!n) {
+        return;
+    }
+    if (n.nodeType === 1 && n.matches && n.matches(sel)) {
+        acc.push(n);
+    }
+    var ch = n.children;
+    if (ch) {
+        for (var i = 0; i < ch.length; i++) {
+            cucuWalkAll(ch[i]);
+        }
+    }
+    if (n.nodeType === 1 && n.shadowRoot) {
+        var sh = n.shadowRoot.children;
+        for (var j = 0; j < sh.length; j++) {
+            cucuWalkAll(sh[j]);
+        }
+    }
+}
+cucuWalkAll(document.documentElement);
+return acc;
+"""
+
+
+def deep_query_selector_first(driver: WebDriver, selector: str):
+    """
+    Return the first element matching the CSS selector in the current frame's
+    document, including inside open shadow roots (depth-first preorder).
+
+    Closed shadow roots are not visible to the page and are skipped. Match
+    behavior for selectors that only exist across shadow boundaries is
+    undefined; prefer simple selectors scoped to a single root when possible.
+
+    parameters:
+      driver    - Selenium WebDriver (current browsing context)
+      selector  - CSS selector string
+    returns:
+      WebElement or None
+    """
+    return driver.execute_script(_DEEP_QUERY_FIRST_JS, selector)
+
+
+def deep_query_selector_all(driver: WebDriver, selector: str):
+    """
+    Return all elements matching the selector in tree order (same traversal as
+    deep_query_selector_first, but every match is collected).
+
+    parameters:
+      driver    - Selenium WebDriver (current browsing context)
+      selector  - CSS selector string
+    returns:
+      list of WebElement (possibly empty)
+    """
+    found = driver.execute_script(_DEEP_QUERY_ALL_JS, selector)
+    return list(found or [])

--- a/tests/test_frames_nested.py
+++ b/tests/test_frames_nested.py
@@ -2,6 +2,7 @@ import pytest
 
 from cucu.browser.core import Browser
 from cucu.browser.frames import (
+    search_in_all_frames,
     search_in_all_frames_nested,
     search_in_all_frames_nested_and_deep,
     switch_to_frame_path,
@@ -73,7 +74,7 @@ def test_search_in_all_frames_nested_bfs_order():
         visited.append(browser.frame_path)
         return None
 
-    search_in_all_frames_nested(browser, search)
+    search_in_all_frames(browser, search, include_nested_frames=True)
     assert visited[0] == ()
     assert visited[1] == ()
     assert visited[2:] == [(0,), (1,), (0, 0)]
@@ -96,7 +97,9 @@ def test_search_in_all_frames_nested_respects_max_depth():
         visited.append(browser.frame_path)
         return None
 
-    search_in_all_frames_nested(browser, search, max_depth=1)
+    search_in_all_frames(
+        browser, search, include_nested_frames=True, max_depth=1
+    )
     assert (0, 0) not in visited
 
 
@@ -118,7 +121,58 @@ def test_search_in_all_frames_nested_returns_first_hit():
             return "second-top"
         return None
 
-    assert search_in_all_frames_nested(browser, search) == "second-top"
+    assert (
+        search_in_all_frames(browser, search, include_nested_frames=True)
+        == "second-top"
+    )
+
+
+def test_search_in_all_frames_shallow_does_not_reach_nested_only_match():
+    f00 = FakeFrame((0, 0))
+    f0 = FakeFrame((0,))
+    browser = MockBrowser(
+        {
+            (): [f0, FakeFrame((1,))],
+            (0,): [f00],
+            (1,): [],
+            (0, 0): [],
+        }
+    )
+
+    def search():
+        if browser.frame_path == (0, 0):
+            return "deep"
+        return None
+
+    assert (
+        search_in_all_frames(browser, search, include_nested_frames=False)
+        is None
+    )
+    assert (
+        search_in_all_frames(browser, search, include_nested_frames=True)
+        == "deep"
+    )
+
+
+def test_search_in_all_frames_nested_wrapper_delegates():
+    f00 = FakeFrame((0, 0))
+    f0 = FakeFrame((0,))
+    browser = MockBrowser(
+        {
+            (): [f0, FakeFrame((1,))],
+            (0,): [f00],
+            (1,): [],
+            (0, 0): [],
+        }
+    )
+    visited: list[tuple[int, ...]] = []
+
+    def search():
+        visited.append(browser.frame_path)
+        return None
+
+    search_in_all_frames_nested(browser, search, max_depth=15)
+    assert visited[2:] == [(0,), (1,), (0, 0)]
 
 
 def test_search_in_all_frames_nested_and_deep_requires_selenium_browser():

--- a/tests/test_frames_nested.py
+++ b/tests/test_frames_nested.py
@@ -1,0 +1,127 @@
+import pytest
+
+from cucu.browser.core import Browser
+from cucu.browser.frames import (
+    search_in_all_frames_nested,
+    search_in_all_frames_nested_and_deep,
+    switch_to_frame_path,
+)
+
+
+class FakeFrame:
+    def __init__(self, path: tuple[int, ...]):
+        self.path = path
+
+
+class MockBrowser:
+    def __init__(self, children_map: dict[tuple[int, ...], list[FakeFrame]]):
+        self._children_map = children_map
+        self._path: tuple[int, ...] = ()
+        self.switch_to_default_count = 0
+        self.switch_to_frame_calls: list[FakeFrame] = []
+
+    @property
+    def frame_path(self) -> tuple[int, ...]:
+        return self._path
+
+    def switch_to_default_frame(self):
+        self.switch_to_default_count += 1
+        self._path = ()
+
+    def switch_to_frame(self, frame: FakeFrame):
+        self.switch_to_frame_calls.append(frame)
+        self._path = frame.path
+
+    def execute(self, javascript, *args, **kwargs):
+        if "iframe" in javascript:
+            return list(self._children_map[self._path])
+        raise AssertionError(f"unexpected script {javascript!r}")
+
+
+def test_switch_to_frame_path_follows_indices():
+    f00 = FakeFrame((0, 0))
+    f0 = FakeFrame((0,))
+    f1 = FakeFrame((1,))
+    browser = MockBrowser(
+        {
+            (): [f0, f1],
+            (0,): [f00],
+            (1,): [],
+            (0, 0): [],
+        }
+    )
+
+    switch_to_frame_path(browser, (0, 0))
+    assert browser.frame_path == (0, 0)
+
+
+def test_search_in_all_frames_nested_bfs_order():
+    f00 = FakeFrame((0, 0))
+    f0 = FakeFrame((0,))
+    f1 = FakeFrame((1,))
+    browser = MockBrowser(
+        {
+            (): [f0, f1],
+            (0,): [f00],
+            (1,): [],
+            (0, 0): [],
+        }
+    )
+    visited: list[tuple[int, ...]] = []
+
+    def search():
+        visited.append(browser.frame_path)
+        return None
+
+    search_in_all_frames_nested(browser, search)
+    assert visited[0] == ()
+    assert visited[1] == ()
+    assert visited[2:] == [(0,), (1,), (0, 0)]
+
+
+def test_search_in_all_frames_nested_respects_max_depth():
+    f00 = FakeFrame((0, 0))
+    f0 = FakeFrame((0,))
+    browser = MockBrowser(
+        {
+            (): [f0, FakeFrame((1,))],
+            (0,): [f00],
+            (1,): [],
+            (0, 0): [],
+        }
+    )
+    visited: list[tuple[int, ...]] = []
+
+    def search():
+        visited.append(browser.frame_path)
+        return None
+
+    search_in_all_frames_nested(browser, search, max_depth=1)
+    assert (0, 0) not in visited
+
+
+def test_search_in_all_frames_nested_returns_first_hit():
+    f00 = FakeFrame((0, 0))
+    f0 = FakeFrame((0,))
+    f1 = FakeFrame((1,))
+    browser = MockBrowser(
+        {
+            (): [f0, f1],
+            (0,): [f00],
+            (1,): [],
+            (0, 0): [],
+        }
+    )
+
+    def search():
+        if browser.frame_path == (1,):
+            return "second-top"
+        return None
+
+    assert search_in_all_frames_nested(browser, search) == "second-top"
+
+
+def test_search_in_all_frames_nested_and_deep_requires_selenium_browser():
+    browser = Browser()
+    with pytest.raises(TypeError):
+        search_in_all_frames_nested_and_deep(browser, "div")

--- a/tests/test_shadow_browser.py
+++ b/tests/test_shadow_browser.py
@@ -1,0 +1,73 @@
+import os
+import urllib.parse
+
+import pytest
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.edge.options import Options as EdgeOptions
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
+
+from cucu.browser.shadow import (
+    deep_query_selector_all,
+    deep_query_selector_first,
+)
+
+
+def _remote_driver():
+    if os.environ.get("CIRCLECI") != "true":
+        pytest.skip("needs Selenium Grid (CircleCI browser matrix)")
+    job = os.environ.get("CIRCLE_JOB", "").lower()
+    if "chrome" in job:
+        options = ChromeOptions()
+    elif "firefox" in job:
+        options = FirefoxOptions()
+    elif "edge" in job:
+        options = EdgeOptions()
+    else:
+        pytest.skip(f"unexpected CIRCLE_JOB {os.environ.get('CIRCLE_JOB')!r}")
+    return webdriver.Remote(
+        command_executor="http://localhost:4444", options=options
+    )
+
+
+@pytest.fixture
+def remote_driver():
+    driver = _remote_driver()
+    try:
+        yield driver
+    finally:
+        driver.quit()
+
+
+def test_deep_query_selector_first_finds_open_shadow_host(remote_driver):
+    html = """<!DOCTYPE html><html><body><div id="h"></div>
+<script>
+const h = document.getElementById("h");
+h.attachShadow({mode: "open"}).innerHTML =
+  '<span id="inner" data-cucu-shadow="1">x</span>';
+</script></body></html>"""
+    remote_driver.get(
+        "data:text/html;charset=utf-8," + urllib.parse.quote(html, safe="")
+    )
+    el = deep_query_selector_first(remote_driver, "[data-cucu-shadow='1']")
+    assert el is not None
+    assert el.get_attribute("id") == "inner"
+
+
+def test_deep_query_selector_all_collects_shadow_matches(remote_driver):
+    html = """<!DOCTYPE html><html><body>
+<div id="a"></div><div id="b"></div>
+<script>
+function host(id) {
+  const el = document.getElementById(id);
+  el.attachShadow({mode: "open"}).innerHTML =
+    '<i class="hit">1</i>';
+}
+host("a");
+host("b");
+</script></body></html>"""
+    remote_driver.get(
+        "data:text/html;charset=utf-8," + urllib.parse.quote(html, safe="")
+    )
+    els = deep_query_selector_all(remote_driver, "i.hit")
+    assert len(els) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.5.0"
+version = "1.4.18"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.17"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
This has been moved to #713
- sorry, I (@ddl-cedricyoung ) took this over and wanted to start the PR review afresh


----
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`search_in_all_frames` only considers the current frame, default content, and **top-level** iframes—no recursion into nested iframes. Standard Selenium CSS queries do not traverse **open** shadow roots. Embedded UIs with deep iframe trees or shadow DOM need ad-hoc workarounds downstream.

Issue Number: https://dominodatalab.atlassian.net/browse/QE-17116

## What is the new behavior?

- **`switch_to_frame_path`** and **`search_in_all_frames_nested`** in [`src/cucu/browser/frames.py`](src/cucu/browser/frames.py): breadth-first walk by iframe **index path** from default content, with `max_depth`, re-resolving `iframe` elements each hop (stale-safe). Same prelude as today (search in current context, then default). Same warning: the session stays in the last frame searched when a match is found.
- **`search_in_all_frames_nested_and_deep`**: BFS frames plus `deep_query_selector_first` per frame; requires Selenium `browser.driver`. Returns `(element, path)` with path semantics documented in code/README.
- **[`src/cucu/browser/shadow.py`](src/cucu/browser/shadow.py)**: **`deep_query_selector_first`** / **`deep_query_selector_all`** — one `execute_script` each, DFS through light DOM and **open** shadow roots only.
- **Opt-in** [`Selenium`](src/cucu/browser/selenium.py) methods **`css_find_elements_nested`** and **`css_find_elements_deep`** (default **`css_find_elements`** unchanged).
- **Tests**: mock BFS in [`tests/test_frames_nested.py`](tests/test_frames_nested.py); optional grid tests in [`tests/test_shadow_browser.py`](tests/test_shadow_browser.py) when `CIRCLECI=true`.
- **Docs / release**: README section, CHANGELOG, version **1.5.0**, `uv.lock`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- **Testing:** `make fix` (ruff, pre-commit, cucu lint, `uv run pytest tests`) — green locally; shadow grid tests in `tests/test_shadow_browser.py` skip unless `CIRCLECI=true`.
- Downstream (e.g. internal-e2e-tests-service) can bump to `cucu>=1.5.0` and replace manual iframe/shadow walks with these imports where appropriate.
- Non-goals unchanged: closed shadow, cross-origin iframe limits.
