### PR TITLE
QE-19297 add cucu lint exclude_tags rule attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.4.18
+- Add - cucu lint `exclude_tags` rule attribute to skip rules on tagged scenarios or features
+
 # 1.4.17
 - Change - more id uniquness to use 12 digits
 - Change - remove lazy load report images

--- a/features/cli/lint.feature
+++ b/features/cli/lint.feature
@@ -480,6 +480,96 @@ Feature: Lint
       """
       And I should see "{STDERR}" is empty
 
+  Scenario: User can exclude rules using exclude_tags
+    Given I create a file at "{CUCU_RESULTS_DIR}/exclude_tags_lint/environment.py" with the following:
+      """
+      from cucu.environment import *
+      from cucu.config import CONFIG
+
+      CONFIG["CUCU_LINT_RULES_PATH"] = "{CUCU_RESULTS_DIR}/exclude_tags_lint/lint_rules"
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/exclude_tags_lint/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/exclude_tags_lint/lint_rules/custom_rules.yaml" with the following:
+      """
+      # custom cucu lint rules
+      ---
+
+      click_step_must_be_followed_by_wait_to:
+        message: a click step must be followed by a `wait to` step
+        type: error
+        exclude_tags: ['@allow-clicks']
+        previous_line:
+          match: '.* I click the (.*)'
+        current_line:
+          # match if the next line does not contain `wait to` in it
+          match: '^((?!wait to).)*$'
+        fix:
+          match: 'I (.*)'
+          replace: 'I wait to \1'
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/exclude_tags_lint/scenario_tag.feature" with the following:
+      """
+      Feature: Tag exclusion mixed feature
+
+        @allow-clicks
+        Scenario: Scenario with tag should be excluded
+          Given I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/buttons.html"
+            And I click the button "button"
+            And I click the button "button"
+            And I wait to see the button "done"
+
+        Scenario: Scenario without tag should be checked
+          Given I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/buttons.html"
+            And I click the button "button"
+            And I click the button "button"
+            And I wait to see the button "done"
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/exclude_tags_lint/feature_tag.feature" with the following:
+      """
+      @allow-clicks
+      Feature: Feature with feature-level tag
+
+        Scenario: Scenario inside tagged feature
+          Given I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/buttons.html"
+            And I click the button "button"
+            And I click the button "button"
+            And I wait to see the button "done"
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/exclude_tags_lint/no_tag.feature" with the following:
+      """
+      Feature: Feature without any exclude tag
+
+        Scenario: Scenario without exclude tag should violate
+          Given I open a browser at the url "http://\{HOST_ADDRESS\}:\{PORT\}/buttons.html"
+            And I click the button "button"
+            And I click the button "button"
+            And I wait to see the button "done"
+      """
+     Then I run the command "cucu lint {CUCU_RESULTS_DIR}/exclude_tags_lint/scenario_tag.feature" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+      And I should see "{STDOUT}" contains the following:
+      """
+      results/exclude_tags_lint/scenario_tag.feature:13: E a click step must be followed by a `wait to` step
+      """
+      And I should see "{STDOUT}" does not contain the following:
+      """
+      results/exclude_tags_lint/scenario_tag.feature:6:
+      """
+     Then I run the command "cucu lint {CUCU_RESULTS_DIR}/exclude_tags_lint/feature_tag.feature" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+      And I should see "{STDOUT}" is equal to the following:
+      """
+      USING RUNNER: behave.runner:Runner
+
+      """
+      And I should see "{STDERR}" is empty
+     Then I run the command "cucu lint {CUCU_RESULTS_DIR}/exclude_tags_lint/no_tag.feature" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+      And I should see "{STDOUT}" contains the following:
+      """
+      results/exclude_tags_lint/no_tag.feature:6: E a click step must be followed by a `wait to` step
+      """
+
   Scenario: User gets appropriate exit code when cucu can not parse the file
     Given I create a file at "{CUCU_RESULTS_DIR}/broken_feature_file_lint/environment.py" with the following:
       """

--- a/features/cli/lint.feature
+++ b/features/cli/lint.feature
@@ -555,7 +555,7 @@ Feature: Lint
       """
       And I should see "{STDOUT}" does not contain the following:
       """
-      results/exclude_tags_lint/scenario_tag.feature:6:
+      results/exclude_tags_lint/scenario_tag.feature:7:
       """
      Then I run the command "cucu lint {CUCU_RESULTS_DIR}/exclude_tags_lint/feature_tag.feature" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
       And I should see "{STDOUT}" is equal to the following:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.17"
+version = "1.4.18"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/lint/linter.py
+++ b/src/cucu/lint/linter.py
@@ -173,6 +173,14 @@ def lint_line(state, rules, steps, line_number, lines, filepath):
         if "exclude" in rule and re.match(rule["exclude"], filepath):
             continue
 
+        # skip rules whose exclude_tags match the active scenario/feature tags
+        if "exclude_tags" in rule:
+            active_tags = state.get(
+                "current_scenario_tags", set()
+            ) | state.get("current_feature_tags", set())
+            if active_tags & set(rule["exclude_tags"]):
+                continue
+
         (current_matcher, current_message) = parse_matcher(
             "current_line",
             rule_name,
@@ -364,12 +372,36 @@ def lint(filepath):
             "'''": False,
         }
 
+        tag_buffer = set()
+        state["current_feature_tags"] = set()
+        state["current_scenario_tags"] = set()
+
         for line in lines:
             state["current_line_number"] = line_number
 
             feature_match = re.match(".*Feature: (.*)", line)
+            scenario_keyword_match = re.match(
+                r"\s*Scenario(?: Outline)?:", line
+            )
+
             if feature_match is not None:
                 state["current_feature_name"] = feature_match.group(1)
+                state["current_feature_tags"] = tag_buffer
+                state["current_scenario_tags"] = set()
+                tag_buffer = set()
+            elif scenario_keyword_match is not None:
+                state["current_scenario_tags"] = tag_buffer
+                tag_buffer = set()
+            else:
+                stripped = line.strip()
+                if stripped.startswith("@"):
+                    tokens = stripped.split()
+                    if all(t.startswith("@") for t in tokens):
+                        tag_buffer.update(tokens)
+                    else:
+                        tag_buffer = set()
+                elif stripped != "":
+                    tag_buffer = set()
 
             scenario_match = re.match("  Scenario: (.*)", line)
 

--- a/src/cucu/lint/linter.py
+++ b/src/cucu/lint/linter.py
@@ -175,10 +175,11 @@ def lint_line(state, rules, steps, line_number, lines, filepath):
 
         # skip rules whose exclude_tags match the active scenario/feature tags
         if "exclude_tags" in rule:
-            active_tags = state.get(
-                "current_scenario_tags", set()
-            ) | state.get("current_feature_tags", set())
-            if active_tags & set(rule["exclude_tags"]):
+            if any(
+                excl in state.get("current_scenario_tags", [])
+                or excl in state.get("current_feature_tags", [])
+                for excl in rule["exclude_tags"]
+            ):
                 continue
 
         (current_matcher, current_message) = parse_matcher(

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -1,0 +1,202 @@
+import pytest
+import pytest_check as check
+
+from cucu.config import CONFIG
+from cucu.lint import linter
+from cucu.lint.linter import lint_line
+
+
+@pytest.mark.parametrize(
+    "rule_extras, scenario_tags, feature_tags, filepath, expect_violation",
+    [
+        pytest.param(
+            {},
+            set(),
+            set(),
+            "/tmp/foo.feature",
+            True,
+            id="rule fires when no exclusions configured",
+        ),
+        pytest.param(
+            {"exclude_tags": ["@no-lint"]},
+            {"@no-lint"},
+            set(),
+            "/tmp/foo.feature",
+            False,
+            id="scenario tag matching exclude_tags skips rule",
+        ),
+        pytest.param(
+            {"exclude_tags": ["@no-lint"]},
+            set(),
+            {"@no-lint"},
+            "/tmp/foo.feature",
+            False,
+            id="feature tag matching exclude_tags skips rule",
+        ),
+        pytest.param(
+            {"exclude_tags": ["@no-lint"]},
+            {"@other-tag"},
+            set(),
+            "/tmp/foo.feature",
+            True,
+            id="non-overlapping tags do not skip rule",
+        ),
+        pytest.param(
+            {"exclude": ".*excluded.*"},
+            set(),
+            set(),
+            "/tmp/excluded.feature",
+            False,
+            id="filepath exclude alone skips rule",
+        ),
+        pytest.param(
+            {"exclude_tags": ["@skip"]},
+            {"@skip"},
+            set(),
+            "/tmp/whatever.feature",
+            False,
+            id="exclude_tags alone skips rule",
+        ),
+    ],
+)
+def test_lint_line_rule_short_circuit(
+    rule_extras, scenario_tags, feature_tags, filepath, expect_violation
+):
+    rule = {
+        "type": "error",
+        "message": "test rule fired",
+        "current_line": {"match": "^trigger$"},
+        **rule_extras,
+    }
+    rules = {"test_rule": rule}
+    state = {
+        "current_scenario_tags": scenario_tags,
+        "current_feature_tags": feature_tags,
+    }
+    violations = lint_line(state, rules, {}, 0, ["trigger"], filepath)
+    if expect_violation:
+        check.equal(len(violations), 1, "expected exactly one violation")
+    else:
+        check.equal(violations, [], "expected no violations")
+
+
+_CLICK_RULE = {
+    "type": "error",
+    "message": "click without wait",
+    "exclude_tags": ["@allow-clicks"],
+    "previous_line": {"match": ".* I click the (.*)"},
+    "current_line": {"match": "^((?!wait to).)*$"},
+}
+
+_TAGGED_SCENARIO = (
+    "Feature: foo\n"
+    "\n"
+    "  @allow-clicks\n"
+    "  Scenario: tagged\n"
+    "    Given I click the button\n"
+    "    Then I click the button\n"
+    "    Then I wait to see done\n"
+)
+
+_UNTAGGED_SCENARIO = (
+    "Feature: foo\n"
+    "\n"
+    "  Scenario: untagged\n"
+    "    Given I click the button\n"
+    "    Then I click the button\n"
+    "    Then I wait to see done\n"
+)
+
+_TAGGED_FEATURE = (
+    "@allow-clicks\n"
+    "Feature: foo\n"
+    "\n"
+    "  Scenario: any\n"
+    "    Given I click the button\n"
+    "    Then I click the button\n"
+    "    Then I wait to see done\n"
+)
+
+_MIXED_SCENARIOS = (
+    "Feature: foo\n"
+    "\n"
+    "  @allow-clicks\n"
+    "  Scenario: tagged\n"
+    "    Given I click the button\n"
+    "    Then I click the button\n"
+    "    Then I wait to see done\n"
+    "\n"
+    "  Scenario: untagged\n"
+    "    Given I click the button\n"
+    "    Then I click the button\n"
+    "    Then I wait to see done\n"
+)
+
+_TAGGED_OUTLINE = (
+    "Feature: foo\n"
+    "\n"
+    "  @allow-clicks\n"
+    "  Scenario Outline: tagged outline\n"
+    "    Given I click the button\n"
+    "    Then I click the button\n"
+    "    Then I wait to see done\n"
+)
+
+
+def _run_lint(tmp_path, monkeypatch, content):
+    feature_path = tmp_path / "test.feature"
+    feature_path.write_text(content)
+
+    monkeypatch.setattr(
+        linter, "load_cucu_steps", lambda filepath=None: ({}, None)
+    )
+    monkeypatch.setattr(
+        linter,
+        "load_builtin_lint_rules",
+        lambda rules: rules.update({"test_rule": _CLICK_RULE}),
+    )
+    monkeypatch.setitem(CONFIG, "CUCU_LINT_RULES_PATH", None)
+
+    return list(linter.lint(str(feature_path)))
+
+
+@pytest.mark.parametrize(
+    "content, expected_violation_lines",
+    [
+        pytest.param(
+            _TAGGED_SCENARIO,
+            [],
+            id="scenario tagged with exclude tag suppresses violations",
+        ),
+        pytest.param(
+            _UNTAGGED_SCENARIO,
+            [4],
+            id="untagged scenario reports violation",
+        ),
+        pytest.param(
+            _TAGGED_FEATURE,
+            [],
+            id="feature-level tag suppresses violations in every scenario",
+        ),
+        pytest.param(
+            _MIXED_SCENARIOS,
+            [10],
+            id="mixed feature reports only the untagged scenario",
+        ),
+        pytest.param(
+            _TAGGED_OUTLINE,
+            [],
+            id="Scenario Outline participates in tag attribution",
+        ),
+    ],
+)
+def test_lint_attributes_tags_to_scope(
+    tmp_path, monkeypatch, content, expected_violation_lines
+):
+    [violations] = _run_lint(tmp_path, monkeypatch, content)
+    actual_lines = [v["location"]["line"] for v in violations]
+    check.equal(
+        actual_lines,
+        expected_violation_lines,
+        f"violation lines mismatch: got {actual_lines}",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.17"
+version = "1.4.18"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
- [x] Feature

## What is the current behavior?
The cucu linter has no way to opt a scenario or feature out of specific lint rules. The only existing filtering is `exclude` (a filepath regex on a rule).

Issue Number: https://dominodatalab.atlassian.net/browse/QE-19297

## What is the new behavior?
Each lint rule may declare an `exclude_tags` list. When the active scenario tags or feature tags intersect that list, the rule is skipped for that line. `exclude` (filepath) and `exclude_tags` are independent — either match short-circuits the rule.

Linter state now tracks `current_scenario_tags` and `current_feature_tags`, populated by buffering `@tag` lines and flushing the buffer onto the next `Feature:` / `Scenario:` / `Scenario Outline:` line. Undefined-step detection is intentionally not silenced by `exclude_tags`.

## Does this PR introduce a breaking change?
- [x] No

## Other information
Coverage: a parametrized pytest module (`tests/test_linter.py`) covers the rule short-circuit logic and end-to-end tag attribution; a behave scenario in `features/cli/lint.feature` exercises scenario-level, feature-level, and untagged (positive control) cases via the CLI.