### PR TITLE
QE-19332 Accept multiple feature paths in cucu run

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -41,7 +41,7 @@ Tests:
 ## Coding Standards
 
 - `make fix` to fix style — never run ruff or cucu lint directly
-- Update `CHANGELOG.md` per PR; bump `pyproject.toml` version + run `uv lock` on release
+- Update `CHANGELOG.md` per PR; bump `pyproject.toml` version + run `uv lock`
 - Minimal `__init__.py`; no relative imports; imports at top of file only
 - `CONFIG` for shared/multi-location values; `ctx` for scenario-scoped values
 - `pathlib` over `os.path`; guard clauses over nesting
@@ -70,7 +70,7 @@ When the user asks to **split** changes into separate branches:
 When the user asks to **update** the current branch with the latest from its base (e.g. "get latest", "merge from latest", "sync with main"): fetch the base (default `origin/main` or `origin/HEAD`), **merge** (do not rebase) into the current branch. If no conflicts, commit and finish. **If conflicts in `pyproject.toml`, `uv.lock`, or `CHANGELOG.md`:** take **theirs** for `pyproject.toml` and `uv.lock`, then bump version once (see **Bump version**) and run `uv lock`; in `CHANGELOG.md`, put a new `# X.Y.Z` at the top with **our** changelog items only, then base's sections in order, and remove conflict markers. Stage resolved files and commit (e.g. "Merge origin/<base> into <branch>"). Resolve any other conflicted files manually.
 
 ### Bump version
-Run `uv version --bump patch`, then add a `# X.Y.Z` section at the top of `CHANGELOG.md` with `- Type - subject` bullets from the PR/commit message (Fix, Add, Change, Chore, etc.). On release, run `uv lock`.
+Run `uv version --bump patch`, then run `uv lock`, then add a `# X.Y.Z` section at the top of `CHANGELOG.md` with `- Type - subject` bullets from the PR/commit message (Fix, Add, Change, Chore, etc.).
 
 ## Step Definitions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # 1.4.19
-- Add - `cucu run` supports comma-separated feature paths (e.g. `cucu run a.feature,b.feature`)
+- Add - `cucu run` supports comma-separated feature paths (e.g. `cucu run a.feature,b.feature`); multiple paths must share a common `features` ancestor directory
 
 # 1.4.18
 - Add - cucu lint `exclude_tags` rule attribute to skip rules on tagged scenarios or features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.4.19
+- Add - `cucu run` supports comma-separated feature paths (e.g. `cucu run a.feature,b.feature`)
+
 # 1.4.18
 - Add - cucu lint `exclude_tags` rule attribute to skip rules on tagged scenarios or features
-- Add - `cucu run` supports comma-separated feature paths (e.g. `cucu run a.feature,b.feature`)
 
 # 1.4.17
 - Change - more id uniquness to use 12 digits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # 1.4.19
-- Add - `cucu run` supports comma-separated feature paths (e.g. `cucu run a.feature,b.feature`); multiple paths must share a common `features` ancestor directory
+- Add - `cucu run` accepts multiple feature paths as separate arguments (e.g. `cucu run a.feature b.feature`); multiple paths must share a common `features` ancestor directory
 
 # 1.4.18
 - Add - cucu lint `exclude_tags` rule attribute to skip rules on tagged scenarios or features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project closely adheres to [Semantic Versioning](https://semver.org/spe
 
 # 1.4.18
 - Add - cucu lint `exclude_tags` rule attribute to skip rules on tagged scenarios or features
+- Add - `cucu run` supports comma-separated feature paths (e.g. `cucu run a.feature,b.feature`)
 
 # 1.4.17
 - Change - more id uniquness to use 12 digits

--- a/features/cli/run.feature
+++ b/features/cli/run.feature
@@ -124,3 +124,10 @@ Feature: Run
       Feature: Feature with passing scenario
       [\s\S]*
       """
+
+  Scenario: User gets an error when comma-separated feature paths do not share a common features ancestor
+    Given I run the command "cucu run data/features/echo.feature,/tmp/other.feature --results {CUCU_RESULTS_DIR}/mismatched_ancestor_results --no-color-output" and save stderr to "STDERR" and expect exit code "1"
+     Then I should see "{STDERR}" matches the following
+      """
+      [\s\S]*comma-separated feature path.*has no 'features' ancestor directory[\s\S]*
+      """

--- a/features/cli/run.feature
+++ b/features/cli/run.feature
@@ -126,7 +126,7 @@ Feature: Run
       """
 
   Scenario: User gets an error when comma-separated feature paths do not share a common features ancestor
-    Given I run the command "cucu run data/features/echo.feature,/tmp/other.feature --results {CUCU_RESULTS_DIR}/mismatched_ancestor_results --no-color-output" and save stderr to "STDERR" and expect exit code "1"
+    Given I run the command "cucu run data/features/echo.feature,/tmp/other.feature --results {CUCU_RESULTS_DIR}/mismatched_ancestor_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
      Then I should see "{STDERR}" matches the following
       """
       [\s\S]*comma-separated feature path.*has no 'features' ancestor directory[\s\S]*

--- a/features/cli/run.feature
+++ b/features/cli/run.feature
@@ -112,3 +112,15 @@ Feature: Run
       .*task timed out.*timeout=3.0.*
       [\s\S]*
       """
+
+  Scenario: User can run multiple feature files specified as a comma-separated list
+    Given I run the command "cucu run data/features/echo.feature,data/features/feature_with_passing_scenario.feature --results {CUCU_RESULTS_DIR}/comma_separated_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     Then I should see the directory at "{CUCU_RESULTS_DIR}/comma_separated_results"
+      And I should see "{STDOUT}" matches the following
+      """
+      [\s\S]*
+      Feature: Echo
+      [\s\S]*
+      Feature: Feature with passing scenario
+      [\s\S]*
+      """

--- a/features/cli/run.feature
+++ b/features/cli/run.feature
@@ -113,9 +113,9 @@ Feature: Run
       [\s\S]*
       """
 
-  Scenario: User can run multiple feature files specified as a comma-separated list
-    Given I run the command "cucu run data/features/echo.feature,data/features/feature_with_passing_scenario.feature --results {CUCU_RESULTS_DIR}/comma_separated_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
-     Then I should see the directory at "{CUCU_RESULTS_DIR}/comma_separated_results"
+  Scenario: User can run multiple feature files specified as separate arguments
+    Given I run the command "cucu run data/features/echo.feature data/features/feature_with_passing_scenario.feature --results {CUCU_RESULTS_DIR}/multi_path_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     Then I should see the directory at "{CUCU_RESULTS_DIR}/multi_path_results"
       And I should see "{STDOUT}" matches the following
       """
       [\s\S]*
@@ -125,9 +125,9 @@ Feature: Run
       [\s\S]*
       """
 
-  Scenario: User gets an error when comma-separated feature paths do not share a common features ancestor
-    Given I run the command "cucu run data/features/echo.feature,/tmp/other.feature --results {CUCU_RESULTS_DIR}/mismatched_ancestor_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+  Scenario: User gets an error when multiple feature paths do not share a common features ancestor
+    Given I run the command "cucu run data/features/echo.feature /tmp/other.feature --results {CUCU_RESULTS_DIR}/mismatched_ancestor_results --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
      Then I should see "{STDERR}" matches the following
       """
-      [\s\S]*comma-separated feature path.*has no 'features' ancestor directory[\s\S]*
+      [\s\S]*feature path.*has no 'features' ancestor directory[\s\S]*
       """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.18"
+version = "1.4.19"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -55,7 +55,7 @@ def main():
 
 
 @main.command()
-@click.argument("filepath", default="features")
+@click.argument("filepath", nargs=-1, type=click.Path(path_type=Path))
 @click.option(
     "-b",
     "--browser",
@@ -242,6 +242,10 @@ def run(
     """
     run a set of feature files
 
+    FILEPATH may be omitted (defaults to the `features` directory), a single
+    file or directory, or multiple files/directories that share a common
+    'features' ancestor directory.
+
     Note: All the os.environ variables are set to be available in the child processes
     """
     init_global_hook_variables()
@@ -306,7 +310,7 @@ def run(
         generate_short_id(worker_id_seed)
     )
 
-    filepaths = [Path(p.strip()) for p in filepath.split(",")]
+    filepaths = list(filepath) or [Path("features")]
 
     if len(filepaths) > 1:
         features_ancestors = set()
@@ -322,15 +326,16 @@ def run(
             )
             if ancestor is None:
                 raise ClickException(
-                    f"comma-separated feature path {fp} has no 'features' ancestor directory"
+                    f"feature path {fp} has no 'features' ancestor directory"
                 )
             features_ancestors.add(ancestor)
         if len(features_ancestors) > 1:
             raise ClickException(
-                "comma-separated feature paths must share a common 'features' ancestor directory"
+                "multiple feature paths must share a common 'features' ancestor directory"
             )
 
-    os.environ["CUCU_FILEPATH"] = CONFIG["CUCU_FILEPATH"] = filepath
+    filepath_str = " ".join(str(p) for p in filepaths)
+    os.environ["CUCU_FILEPATH"] = CONFIG["CUCU_FILEPATH"] = filepath_str
 
     create_run(results, filepaths)
 

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -55,9 +55,7 @@ def main():
 
 
 @main.command()
-@click.argument(
-    "filepath", default="features", type=click.Path(path_type=Path)
-)
+@click.argument("filepath", default="features")
 @click.option(
     "-b",
     "--browser",
@@ -308,9 +306,11 @@ def run(
         generate_short_id(worker_id_seed)
     )
 
-    os.environ["CUCU_FILEPATH"] = CONFIG["CUCU_FILEPATH"] = str(filepath)
+    filepaths = [Path(p.strip()) for p in filepath.split(",")]
 
-    create_run(results, filepath)
+    os.environ["CUCU_FILEPATH"] = CONFIG["CUCU_FILEPATH"] = filepath
+
+    create_run(results, filepaths)
 
     try:
         if workers is None or workers == 1:
@@ -335,7 +335,7 @@ def run(
                 register_after_all_hook(cancel_timer)
 
             exit_code = behave(
-                filepath,
+                filepaths,
                 color_output,
                 dry_run,
                 env,
@@ -360,10 +360,12 @@ def run(
             logger.debug(
                 f"Starting cucu_run {CONFIG['CUCU_RUN_ID']} with multiple workers: {workers}"
             )
-            if filepath.is_dir():
-                feature_filepaths = list(filepath.rglob("*.feature"))
-            else:
-                feature_filepaths = [filepath]
+            feature_filepaths = []
+            for fp in filepaths:
+                if fp.is_dir():
+                    feature_filepaths.extend(fp.rglob("*.feature"))
+                else:
+                    feature_filepaths.append(fp)
 
             if sys.platform == "darwin":
                 logger.info(
@@ -430,7 +432,7 @@ def run(
                     async_results[feature_filepath] = pool.apply_async(
                         behave,
                         [
-                            feature_filepath,
+                            [feature_filepath],
                             color_output,
                             dry_run,
                             env,

--- a/src/cucu/cli/core.py
+++ b/src/cucu/cli/core.py
@@ -308,6 +308,28 @@ def run(
 
     filepaths = [Path(p.strip()) for p in filepath.split(",")]
 
+    if len(filepaths) > 1:
+        features_ancestors = set()
+        for fp in filepaths:
+            resolved = fp.resolve()
+            ancestor = next(
+                (
+                    a
+                    for a in [resolved, *resolved.parents]
+                    if a.name == "features"
+                ),
+                None,
+            )
+            if ancestor is None:
+                raise ClickException(
+                    f"comma-separated feature path {fp} has no 'features' ancestor directory"
+                )
+            features_ancestors.add(ancestor)
+        if len(features_ancestors) > 1:
+            raise ClickException(
+                "comma-separated feature paths must share a common 'features' ancestor directory"
+            )
+
     os.environ["CUCU_FILEPATH"] = CONFIG["CUCU_FILEPATH"] = filepath
 
     create_run(results, filepaths)

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -54,7 +54,8 @@ def behave(
     if len(filepaths) > 1:
         resolved = filepaths[0].resolve()
         cucurc_anchor = next(
-            a for a in [resolved, *resolved.parents] if a.name == "features"
+            (a for a in [resolved, *resolved.parents] if a.name == "features"),
+            filepaths[0],
         )
     else:
         cucurc_anchor = filepaths[0]
@@ -205,7 +206,7 @@ def create_run(results_path: Path, filepaths: list):
 
     run_details = {
         "cucu_run_id": CONFIG["CUCU_RUN_ID"],
-        "filepath": ",".join(str(p) for p in filepaths),
+        "filepath": " ".join(str(p) for p in filepaths),
         "full_arguments": sys.argv,
         "env": env_values,
         "date": datetime.now().isoformat(),

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -51,7 +51,14 @@ def behave(
     chrome_profile_dir=None,
 ):
     # load all them configs
-    CONFIG.load_cucurc_files(filepaths[0])
+    if len(filepaths) > 1:
+        resolved = filepaths[0].resolve()
+        cucurc_anchor = next(
+            a for a in [resolved, *resolved.parents] if a.name == "features"
+        )
+    else:
+        cucurc_anchor = filepaths[0]
+    CONFIG.load_cucurc_files(cucurc_anchor)
 
     if chrome_profile_dir is not None:
         os.environ["CUCU_CHROME_PROFILE_DIR"] = str(chrome_profile_dir)

--- a/src/cucu/cli/run.py
+++ b/src/cucu/cli/run.py
@@ -32,7 +32,7 @@ def behave_init(filepath="features"):
 
 
 def behave(
-    filepath,
+    filepaths,
     color_output,
     dry_run,
     env,
@@ -51,7 +51,7 @@ def behave(
     chrome_profile_dir=None,
 ):
     # load all them configs
-    CONFIG.load_cucurc_files(filepath)
+    CONFIG.load_cucurc_files(filepaths[0])
 
     if chrome_profile_dir is not None:
         os.environ["CUCU_CHROME_PROFILE_DIR"] = str(chrome_profile_dir)
@@ -100,7 +100,7 @@ def behave(
 
     run_json_filename = "run.json"
     if redirect_output:
-        feature_name = get_feature_name(filepath)
+        feature_name = get_feature_name(filepaths[0])
         run_json_filename = f"{feature_name}-run.json"
 
     if dry_run:
@@ -143,13 +143,17 @@ def behave(
     if not show_skips:
         args.append("--no-skipped")
 
-    args.append(filepath)
-    os.environ["BEHAVE_FILEPATH"] = CONFIG["BEHAVE_FILEPATH"] = str(filepath)
+    args.extend([str(p) for p in filepaths])
+    os.environ["BEHAVE_FILEPATH"] = CONFIG["BEHAVE_FILEPATH"] = str(
+        filepaths[0]
+    )
 
     result = 0
     try:
         if redirect_output:
-            cucu_log_path = behave_filepath_to_cucu_logpath(filepath, results)
+            cucu_log_path = behave_filepath_to_cucu_logpath(
+                filepaths[0], results
+            )
 
             CONFIG["__CUCU_PARENT_STDOUT"] = sys.stdout
 
@@ -180,7 +184,7 @@ def behave(
     return result
 
 
-def create_run(results_path: Path, filepath: Path):
+def create_run(results_path: Path, filepaths: list):
     run_json_filepath = results_path / "run_details.json"
 
     if run_json_filepath.exists():
@@ -194,7 +198,7 @@ def create_run(results_path: Path, filepath: Path):
 
     run_details = {
         "cucu_run_id": CONFIG["CUCU_RUN_ID"],
-        "filepath": str(filepath),
+        "filepath": ",".join(str(p) for p in filepaths),
         "full_arguments": sys.argv,
         "env": env_values,
         "date": datetime.now().isoformat(),

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.18"
+version = "1.4.19"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
QE-19332 Accept multiple feature paths in cucu run

- accept multiple feature paths as separate positional arguments in `cucu run` (e.g. `cucu run a.feature:4 b.feature:7`) so callers can target multiple specific scenarios in one invocation; behave parses `:linenumber` natively, so per-file line postfixes work without any cucu-side parsing
- require all paths to share a common `features` ancestor directory when multiple are given; fail with a clear `ClickException` otherwise, so cucurc loading has a single, predictable anchor
- load cucurc files from that common `features` ancestor when multiple paths are given, falling back to `filepaths[0]` if no ancestor is found so direct callers of `behave()` don't crash
- thread the path list through single-worker and multi-worker code paths; multi-worker mode expands each entry (directories → rglob, files → as-is) and dispatches one worker per file
- store the space-joined paths in `run_details.json` and `CUCU_FILEPATH` for traceability
- expand the `cucu run --help` docstring to describe the new multi-path shape and the shared-`features`-ancestor requirement
- add feature scenarios covering the multi-path happy path and the ancestor-mismatch error
- update the `Bump version` rule in `copilot-instructions.md` to run `uv lock` alongside the version bump (not only on release), so the lockfile stays in sync per-PR

## Info
Ticket: https://dominodatalab.atlassian.net/browse/QE-19332

## Testing
- [x] `make fix` — clean
- [x] `uv run pytest tests` — 54 passed
- [x] `uv run cucu run features/cli/run.feature:116` — multi-path happy scenario passes
- [x] `uv run cucu run features/cli/run.feature:128` — mismatched-ancestor error scenario passes; STDERR matches `Error: feature path /tmp/other.feature has no 'features' ancestor directory`
- [x] `uv run cucu run --help` — usage shows `[FILEPATH]...` and the updated docstring renders

## For reviewers
Not a breaking change — single-path and directory inputs behave identically. An omitted positional falls back to `[Path("features")]`, and a single path is just a one-element list.

`:linenumber` postfixes are not interpreted by cucu; the strings are passed straight to behave, which already supports `path:line`.

The multi-worker code path was generalised from a single `filepath.is_dir()` check to a loop over `filepaths`. For multi-path runs, cucurc loading anchors at the common `features` ancestor rather than each individual feature file's directory — a deliberate trade-off so configuration is deterministic regardless of which path appears first.

This PR was initially implemented with a single comma-separated argument (`a.feature,b.feature`) and then revised to use Click's native `nargs=-1` variadic positional pattern per review feedback; the commit history reflects both phases.
