### PR TITLE
QE-19238 make fuzzycase aware not case sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.4.19
+- Change - fuzzy find matching is now case-aware, not case-sensitive
+  - case-different text enters the candidate pool: query `"project"` now finds `Project`/`PrOjEcT`
+  - exact-case match still outranks caseless match for the same element area
+
 # 1.4.18
 - Add - cucu lint `exclude_tags` rule attribute to skip rules on tagged scenarios or features
 

--- a/data/www/fuzzy_case_rules.html
+++ b/data/www/fuzzy_case_rules.html
@@ -1,0 +1,33 @@
+<html>
+  <head>
+    <title>Fuzzy Case-Aware Rules</title>
+    <script>
+    function update(value) {
+      document.querySelector("#input").value = value;
+    }
+    </script>
+  </head>
+  <body>
+    <label>value:</label><input id="input" type="text"></input>
+    <hr/>
+    <!-- Ranking trio: same text in three cases. Each writes a distinctive
+         payload so the assertion proves which one was actually clicked. -->
+    <button onclick="update('exact case lowercase');">project</button>
+    <button onclick="update('title case Project');">Project</button>
+    <button onclick="update('crazy case PrOjEcT');">PrOjEcT</button>
+    <hr/>
+    <!-- Caseless-only: only one variant present, query with different case. -->
+    <button onclick="update('Settings clicked');">Settings</button>
+    <hr/>
+    <!-- Caseless attribute: aria-label carries the term, inner text doesn't. -->
+    <button onclick="update('Save via aria-label');" aria-label="Save">a button</button>
+    <hr/>
+    <!-- Tiebreak: two caseless variants with no exact-case lowercase variant
+         on the page. Both score the same (immediate + caselessexact = 500),
+         so DOM order (pass index) breaks the tie. A different word from the
+         ranking trio guarantees no lowercase 'dashboard' is present. Also
+         serves as filler for the no-match-query scenario. -->
+    <button onclick="update('Dashboard first in DOM');">Dashboard</button>
+    <button onclick="update('DaShBoArD second in DOM');">DaShBoArD</button>
+  </body>
+</html>

--- a/features/browser/fuzzy_rules.feature
+++ b/features/browser/fuzzy_rules.feature
@@ -23,3 +23,46 @@ Feature: Fuzzy rules
        """
        When I select the option "Apple" from the dropdown "Pick a color"
        """
+
+  Scenario: Exact-case match outranks caseless variants
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/fuzzy_case_rules.html"
+     Then I should see no value in the input "value:"
+     When I click the button "project"
+     Then I should see "exact case lowercase" in the input "value:"
+     When I click the button "PrOjEcT"
+     Then I should see "crazy case PrOjEcT" in the input "value:"
+     When I click the button "Project"
+     Then I should see "title case Project" in the input "value:"
+
+  Scenario: Caseless match locates the element when only different-case exists
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/fuzzy_case_rules.html"
+     Then I should see no value in the input "value:"
+     When I click the button "settings"
+     Then I should see "Settings clicked" in the input "value:"
+     When I click the button "SETTINGS"
+     Then I should see "Settings clicked" in the input "value:"
+
+  Scenario: Caseless match via attribute still works
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/fuzzy_case_rules.html"
+     Then I should see no value in the input "value:"
+     When I click the button "save"
+     Then I should see "Save via aria-label" in the input "value:"
+
+  Scenario: Caseless widening does not match unrelated text
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/fuzzy_case_rules.html"
+     Then I should see no value in the input "value:"
+     Then I wait up to "1" seconds to see the following steps fail
+       """
+       When I click the button "nonexistent-button-text"
+       """
+
+  Scenario: DOM order breaks ties among caseless matches
+    Given I start a webserver at directory "data/www" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/fuzzy_case_rules.html"
+     Then I should see no value in the input "value:"
+     When I click the button "dashboard"
+     Then I should see "Dashboard first in DOM" in the input "value:"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.18"
+version = "1.4.19"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/fuzzy/fuzzy.js
+++ b/src/cucu/fuzzy/fuzzy.js
@@ -7,10 +7,14 @@
      * custom jquery matchers:
      *
      *
-     *  has_text - matches an element with the exact text provided.
+     *  has_text    - matches an element with the exact text provided.
      *
-     *  vis      - matches an element that is visible and has at least
-     *             one visible parent.
+     *  has_text_ci - case-insensitive variant of has_text.
+     *
+     *  icontains   - case-insensitive variant of jQuery's :contains.
+     *
+     *  vis         - matches an element that is visible and has at least
+     *                one visible parent.
      *
      */
     jqCucu.extend(
@@ -18,6 +22,12 @@
         {
             has_text: function(elem, index, match) {
                 return (elem.textContent || elem.innerText || jqCucu(elem).text() || '').trim() === match[3].trim();
+            },
+            has_text_ci: function(elem, index, match) {
+                return (elem.textContent || elem.innerText || jqCucu(elem).text() || '').trim().toLowerCase() === match[3].trim().toLowerCase();
+            },
+            icontains: function(elem, index, match) {
+                return (elem.textContent || elem.innerText || jqCucu(elem).text() || '').toLowerCase().indexOf(match[3].toLowerCase()) !== -1;
             },
             vis: function (elem) {
                 return !(jqCucu(elem).is(":hidden") || jqCucu(elem).css("width") == "0px" || jqCucu(elem).css("height") == "0px" || jqCucu(elem).parents(":hidden").length);
@@ -77,17 +87,20 @@
     /*
      * Relevance scoring (ordering)
      *
-     * Case-sensitive matching. Higher scores rank first. After scoring, we
-     * deduplicate and sort by score desc, then by original discovery order
-     * (`pass`) asc as a tiebreaker. The `index` returned by fuzzy_find is
-     * the Nth best-ranked element after this sort.
+     * Case-aware matching: candidates are accepted regardless of case, but
+     * within each area an exact-case match outranks a caseless match
+     * (exact > caselessexact > substring > caselesssubstring). Higher scores
+     * rank first. After scoring, we deduplicate and sort by score desc, then
+     * by original discovery order (`pass`) asc as a tiebreaker. The `index`
+     * returned by fuzzy_find is the Nth best-ranked element after this sort.
      *
      * Area priority (highest → lowest):
      *   1) Immediate text content (direct TEXT_NODE children only)
      *   2) Attribute content with sub-weights (aria-label > id > class; others default)
      *   3) Full text content (includes children)
      *
-     * Within each area, exact match outranks substring match.
+     * Within each area, exact match outranks substring match, and case-sensitive
+     * outranks case-insensitive within each of those.
      *
      * Empty text fallback: if nothing matches and the element has empty
      * full text, a small default score is applied so empty-but-possibly
@@ -104,6 +117,16 @@
             return hay.trim() === needle.trim();
         }
 
+        function includesCi(hay, needle) {
+            if (!hay) return false;
+            return hay.toLowerCase().indexOf(needle.toLowerCase()) !== -1;
+        }
+
+        function equalsCi(hay, needle) {
+            if (!hay) return false;
+            return hay.trim().toLowerCase() === needle.trim().toLowerCase();
+        }
+
         var best = 0;
         var higherPriorityMatchFound = false;
 
@@ -111,8 +134,14 @@
         if (equals(imm, query)) {
             best = Math.max(best, WEIGHTS.area.immediate + WEIGHTS.match.exact);
             higherPriorityMatchFound = true;
+        } else if (equalsCi(imm, query)) {
+            best = Math.max(best, WEIGHTS.area.immediate + WEIGHTS.match.caselessexact);
+            higherPriorityMatchFound = true;
         } else if (includes(imm, query)) {
             best = Math.max(best, WEIGHTS.area.immediate + WEIGHTS.match.substring);
+            higherPriorityMatchFound = true;
+        } else if (includesCi(imm, query)) {
+            best = Math.max(best, WEIGHTS.area.immediate + WEIGHTS.match.caselesssubstring);
             higherPriorityMatchFound = true;
         }
 
@@ -142,9 +171,15 @@
             // Only promote exact full text matches to immediate weight when no higher priority matches found
             var fullTextWeight = (!higherPriorityMatchFound) ? WEIGHTS.area.immediate : WEIGHTS.area.fulltext;
             best = Math.max(best, fullTextWeight + WEIGHTS.match.exact);
+        } else if (equalsCi(ft, query)) {
+            // Caseless-exact full text matches are promoted on the same rule as exact ones
+            var fullTextWeightCi = (!higherPriorityMatchFound) ? WEIGHTS.area.immediate : WEIGHTS.area.fulltext;
+            best = Math.max(best, fullTextWeightCi + WEIGHTS.match.caselessexact);
         } else if (includes(ft, query)) {
             // Substring matches never get promoted
             best = Math.max(best, WEIGHTS.area.fulltext + WEIGHTS.match.substring);
+        } else if (includesCi(ft, query)) {
+            best = Math.max(best, WEIGHTS.area.fulltext + WEIGHTS.match.caselesssubstring);
         }
 
         if (best === 0 && ft.length === 0) {
@@ -185,7 +220,7 @@
         var elements = [];
         var results = null;
         var attributes = ['aria-label', 'title', 'placeholder', 'value'];
-        var matchers = ['has_text', 'contains'];
+        var matchers = ['has_text', 'has_text_ci', 'contains', 'icontains'];
 
         name = name.replaceAll('"', '\\"');
 
@@ -215,9 +250,28 @@
                         var nameIsAttributeJq = `${thing}[${attribute_name}="${name}"]:vis`;
                         results = jqCucu(nameIsAttributeJq, document.body).toArray();
                         if (cucu.debug) { console.log(nameIsAttributeLabel, results); }
+                    } else if (matcher == 'has_text_ci') {
+                        // Sizzle does not parse the CSS-L4 `[attr=val i]` flag,
+                        // so filter case-insensitively in JS.
+                        var nameLowerExactAttr = name.toLowerCase();
+                        var attrNameExactCi = attribute_name;
+                        results = jqCucu(`${thing}:vis`, document.body).filter(function(){
+                            var val = this.getAttribute(attrNameExactCi);
+                            return val !== null && val.toLowerCase() === nameLowerExactAttr;
+                        }).toArray();
+                        if (cucu.debug) { console.log(nameIsAttributeLabel, results); }
                     } else if (matcher == 'contains') {
                         var nameInAttributeJq = `${thing}[${attribute_name}*="${name}"]:vis`;
                         results = jqCucu(nameInAttributeJq, document.body).toArray();
+                        if (cucu.debug) { console.log(nameIsAttributeLabel, results); }
+                    } else if (matcher == 'icontains') {
+                        // See note above; Sizzle does not parse the `i` flag.
+                        var nameLowerSubAttr = name.toLowerCase();
+                        var attrNameSubCi = attribute_name;
+                        results = jqCucu(`${thing}:vis`, document.body).filter(function(){
+                            var val = this.getAttribute(attrNameSubCi);
+                            return val !== null && val.toLowerCase().indexOf(nameLowerSubAttr) !== -1;
+                        }).toArray();
                         if (cucu.debug) { console.log(nameIsAttributeLabel, results); }
                     }
                     elements = elements.concat(results.map(x => ({element: x, label: nameIsAttributeLabel, label_name: 'nameIsAttribute'})));
@@ -242,11 +296,27 @@
                         return this.value == name;
                     }).toArray();
                     if (cucu.debug) { console.log(nameIsValueLabel, results); }
+                } else if (matcher == 'has_text_ci') {
+                    var nameInValueLabel = `${thing} value="${name}" i></${thing}>`;
+                    var nameInValueJq = `${thing}:vis`;
+                    var nameLowerExact = name.toLowerCase();
+                    results = jqCucu(nameInValueJq, document.body).filter(function(){
+                        return this.value !== undefined && String(this.value).toLowerCase() === nameLowerExact;
+                    }).toArray();
+                    if (cucu.debug) { console.log(nameInValueLabel, results); }
                 } else if (matcher == 'contains') {
                     var nameInValueLabel = `${thing} value*="${name}"></${thing}>`;
                     var nameInValueJq = `${thing}:vis`;
                     results = jqCucu(nameInValueJq, document.body).filter(function(){
                         return this.value !== undefined && String(this.value).indexOf(name) != -1;
+                    }).toArray();
+                    if (cucu.debug) { console.log(nameInValueLabel, results); }
+                } else if (matcher == 'icontains') {
+                    var nameInValueLabel = `${thing} value*="${name}" i></${thing}>`;
+                    var nameInValueJq = `${thing}:vis`;
+                    var nameLowerSub = name.toLowerCase();
+                    results = jqCucu(nameInValueJq, document.body).filter(function(){
+                        return this.value !== undefined && String(this.value).toLowerCase().indexOf(nameLowerSub) != -1;
                     }).toArray();
                     if (cucu.debug) { console.log(nameInValueLabel, results); }
                 }
@@ -289,7 +359,18 @@
                 for(var aIndex=0; aIndex < attributes.length; aIndex++) {
                     var attribute_name = attributes[aIndex];
                     var innerNestedElementsLabel = `<${thing}><* ${attribute_name}="${name}"></*></${thing}>`;
-                    results = jqCucu(`*:vis[${attribute_name}="${name}"]`, document.body).parents(thing).toArray();
+                    var caseInsensitiveAttr = (matcher == 'has_text_ci' || matcher == 'icontains');
+                    if (caseInsensitiveAttr) {
+                        // Sizzle does not parse `[attr=val i]`; filter in JS.
+                        var nameLowerNested = name.toLowerCase();
+                        var attrNameNested = attribute_name;
+                        results = jqCucu(`*:vis`, document.body).filter(function(){
+                            var val = this.getAttribute(attrNameNested);
+                            return val !== null && val.toLowerCase() === nameLowerNested;
+                        }).parents(thing).toArray();
+                    } else {
+                        results = jqCucu(`*:vis[${attribute_name}="${name}"]`, document.body).parents(thing).toArray();
+                    }
                     if (cucu.debug) { console.log(innerNestedElementsLabel, results); }
                     elements = elements.concat(results.map(x => ({element: x, label: innerNestedElementsLabel, label_name: 'innerNestedElements'})));
                 }

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.18"
+version = "1.4.19"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://dominodatalab.atlassian.net/browse/QE-19238

## What is the new behavior?
cucu is case aware not case sensitive
  - case-different text enters the candidate pool: query `"project"` now finds `Project`/`PrOjEcT`
  - exact-case match still outranks caseless match for the same element area

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
