### PR TITLE
QE-19354 Wait for page to load before interacting with dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.4.21
+- Fix - dropdown steps wait for page load before locating the dropdown to avoid races on freshly-loaded pages
+
 # 1.4.20
 - Change - fuzzy find matching is now case-aware, not case-sensitive
   - case-different text enters the candidate pool: query `"project"` now finds `Project`/`PrOjEcT`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.20"
+version = "1.4.21"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/steps/dropdown_steps.py
+++ b/src/cucu/steps/dropdown_steps.py
@@ -183,6 +183,7 @@ def find_n_select_dropdown_option(ctx, dropdown, option, index=0):
       index(str):  the index of the dropdown if there are duplicates
     """
     ctx.check_browser_initialized()
+    ctx.browser.wait_for_page_to_load()
 
     dropdown_element = find_dropdown(ctx, dropdown, index)
 
@@ -227,6 +228,7 @@ def find_n_select_dynamic_dropdown_option(ctx, dropdown, option, index=0):
       index(str):  the index of the dropdown if there are duplicates
     """
     ctx.check_browser_initialized()
+    ctx.browser.wait_for_page_to_load()
 
     dropdown_element = find_dropdown(ctx, dropdown, index)
 
@@ -294,6 +296,7 @@ def assert_dropdown_option_selected(
       index(str):  the index of the dropdown if there are duplicates
     """
     ctx.check_browser_initialized()
+    ctx.browser.wait_for_page_to_load()
 
     dropdown_element = find_dropdown(ctx, dropdown, index)
     if dropdown_element is None:

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.20"
+version = "1.4.21"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
QE-19354 Wait for page to load before interacting with dropdowns

- wait for page load inside dropdown select / dynamic-select / assert-option-selected helpers so steps don't race ahead of a freshly-navigated page
- bump to 1.4.22

## Info
Ticket: https://dominodatalab.atlassian.net/browse/QE-19354

## Testing
- [x] `make fix`
- [x] `uv run pytest tests`

## For reviewers
Three-line behavioral change in `src/cucu/steps/dropdown_steps.py` — each affected helper (`find_n_select_dropdown_option`, `find_n_select_dynamic_dropdown_option`, `assert_dropdown_option_selected`) now calls `ctx.browser.wait_for_page_to_load()` right after `check_browser_initialized()`, matching the pattern already used elsewhere. Not a breaking change; existing waits in calling scenarios become redundant but stay safe.
