### PR TITLE
QE-19392 Tighten Renovate dependency update policies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,6 @@ cucu = "cucu.cli:main"
 requires = ["uv_build>=0.11.1,<0.12.0"]
 build-backend = "uv_build"
 
-[tool.uv]
-exclude-newer = "2 weeks"
-
 [tool.uv.build-backend]
 source-include = ["CHANGELOG.md"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ cucu = "cucu.cli:main"
 requires = ["uv_build>=0.11.1,<0.12.0"]
 build-backend = "uv_build"
 
+[tool.uv]
+exclude-newer = "2 weeks"
+
 [tool.uv.build-backend]
 source-include = ["CHANGELOG.md"]
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "ignorePaths": [
     "**/.python-version"
   ],
+  "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": false
   },

--- a/renovate.json
+++ b/renovate.json
@@ -34,12 +34,23 @@
       ]
     },
     {
-      "description": "Ignore behave version updates due to compatibility issues",
+      "description": "Ignore behave and selenium version updates due to compatibility issues",
       "matchDatasources": [
         "pypi"
       ],
       "matchPackageNames": [
-        "behave"
+        "behave",
+        "selenium"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Ignore selenium Docker image updates",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackagePatterns": [
+        "^selenium/"
       ],
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
   "ignorePaths": [
     "**/.python-version"
   ],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchCategories": [
@@ -16,7 +19,7 @@
       "enabled": true
     },
     {
-      "groupName": "glom all dependencies",
+      "groupName": "all dependencies",
       "matchFileNames": [
         "**"
       ],
@@ -25,7 +28,9 @@
       "matchUpdateTypes": [
         "major",
         "minor",
-        "patch"
+        "patch",
+        "digest",
+        "pin"
       ]
     },
     {


### PR DESCRIPTION
QE-19392 Tighten Renovate dependency update policies

- require a 14-day release age in `renovate.json` before Renovate opens update PRs, reducing exposure to quickly-reverted releases
- disable `lockFileMaintenance` to stop separate lockfile-only PRs
- group all update types (`major`, `minor`, `patch`, `digest`, `pin`) into a single combined PR and rename the group from "glom all dependencies" to "all dependencies"
- exclude `selenium` (PyPI and Docker) from Renovate updates alongside the existing `behave` exclusion to avoid compatibility breakage

## Info
Ticket: https://dominodatalab.atlassian.net/browse/QE-19392

## Testing
- [x] Reviewed `renovate.json` diff for correctness

## For reviewers
Config-only change to `renovate.json`. The release age gate and selenium exclusion are the most impactful additions; the grouping and lockfile changes reduce PR noise. No code changes.

### Suggested review order
1. `renovate.json` — release age gate, lockfile maintenance disable, grouping rule, selenium exclusion
