### PR TITLE
Ddl kavya qe 19421 emit error child element for errored scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.4.27
+- Fix - JUnit formatter emits an `<error>` child element for errored scenarios (e.g. hook failures), so standard JUnit consumers (CircleCI, TestRail) classify them as errors instead of silently reporting them as passed
+
 # 1.4.26
 - Fix - populate scenario `start_at` in DB at row creation time to prevent `None` on worker crash; prevents reporter `TypeError` when computing step time offsets
 - Fix - report generator guards against scenario `start_at` being `None` (defensive against incomplete DB records)

--- a/features/cli/run_with_junit.feature
+++ b/features/cli/run_with_junit.feature
@@ -38,3 +38,38 @@ Feature: Run with JUnit
       """
       raise AssertionError("step fails on purpose")
       """
+
+  Scenario: User gets an <error> element in the JUnit XML for an errored scenario
+    Given I create a file at "{CUCU_RESULTS_DIR}/junit_error/environment.py" with the following:
+      """
+      from cucu.environment import *
+      from cucu import register_before_scenario_hook
+
+      def before_scenario_fail(ctx):
+          raise AssertionError("boom")
+
+      register_before_scenario_hook(before_scenario_fail)
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/junit_error/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/junit_error/echo.feature" with the following:
+      """
+      Feature: Feature that errors on a before hook
+
+        Scenario: Hello world scenario
+          Given I echo "Hello World"
+      """
+        * # a failing before_scenario hook reports as error, not failure, so the
+        * # JUnit testcase must carry an <error> child for standard consumers
+        * # (CircleCI, TestRail) to classify it as an error and not a pass
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/junit_error/echo.feature --show-skips --results {CUCU_RESULTS_DIR}/junit_error_results" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+     Then I should see the file at "{CUCU_RESULTS_DIR}/junit_error_results/Feature that errors on a before hook.xml" contains the following:
+      """
+      <error>
+      """
+      And I should see the file at "{CUCU_RESULTS_DIR}/junit_error_results/Feature that errors on a before hook.xml" contains the following:
+      """
+      HOOK-ERROR in before_scenario_fail: AssertionError: boom
+      """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.26"
+version = "1.4.27"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/formatter/junit.py
+++ b/src/cucu/formatter/junit.py
@@ -77,31 +77,25 @@ class CucuJUnitFormatter(Formatter):
                 # error-like status (predominantly a before/after-scenario hook
                 # failure, where no step ran; see environment.py). Standard JUnit
                 # consumers classify a testcase by its child element, so we must
-                # capture details and emit an <error> child below.
-                details = (
-                    self._collect_hook_error_lines()
-                    + self._collect_detail_lines()
-                )
+                # capture the hook error message and emit an <error> child below.
+                details = []
+                for results_attr in (
+                    "before_hook_results",
+                    "after_hook_results",
+                ):
+                    for hook_result in getattr(
+                        self.current_scenario, results_attr, []
+                    ):
+                        if hook_result.get("status") == "error":
+                            details += hook_result.get("error_message", [])
+
+                details += self._collect_detail_lines()
                 if not details:
                     details = [f"scenario errored with status: {status}"]
                 self.current_scenario_results["error"] = details
 
             if status == "skipped":
                 self.current_scenario_results["skipped"] = True
-
-    def _collect_hook_error_lines(self):
-        """
-        collect the error message lines captured by failing before/after
-        scenario hooks (see _run_hook in environment.py)
-        """
-        lines = []
-        for results_attr in ("before_hook_results", "after_hook_results"):
-            for hook_result in getattr(
-                self.current_scenario, results_attr, []
-            ):
-                if hook_result.get("status") == "error":
-                    lines += hook_result.get("error_message", [])
-        return lines
 
     def _collect_detail_lines(self):
         """

--- a/src/cucu/formatter/junit.py
+++ b/src/cucu/formatter/junit.py
@@ -68,45 +68,79 @@ class CucuJUnitFormatter(Formatter):
                 status = self.current_scenario.compute_status().name
 
             self.current_scenario_results["status"] = status
-            failures = []
 
             if status == "failed" and self.current_scenario_traceback:
-                failure_handlers = CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"]
-
-                for failure_handler in failure_handlers:
-                    failures.append(
-                        failure_handler(
-                            self.current_feature, self.current_scenario
-                        )
-                    )
-
-                failures += [
-                    f"{self.current_step.keyword} {self.current_step.name} (after {round(self.current_step.duration, 3)}s)"
-                ]
-
-                if error := self.current_step.exception:
-                    if isinstance(error, RetryError):
-                        error = error.last_attempt.exception()
-
-                    if len(error.args) > 0 and isinstance(error.args[0], str):
-                        error_class_name = error.__class__.__name__
-                        error_lines = error.args[0].splitlines()
-                        error_lines[0] = (
-                            f"{error_class_name}: {error_lines[0]}"
-                        )
-                    else:
-                        error_lines = [repr(error)]
-                    failures += error_lines
-
-                if CONFIG["CUCU_JUNIT_WITH_STACKTRACE"] == "true":
-                    failures += traceback.format_tb(
-                        self.current_scenario_traceback
-                    )
-
-                self.current_scenario_results["failure"] = failures
+                self.current_scenario_results["failure"] = (
+                    self._collect_detail_lines()
+                )
+            elif status not in ("passed", "failed", "skipped"):
+                # error-like status (predominantly a before/after-scenario hook
+                # failure, where no step ran; see environment.py). Standard JUnit
+                # consumers classify a testcase by its child element, so we must
+                # capture details and emit an <error> child below.
+                details = (
+                    self._collect_hook_error_lines()
+                    + self._collect_detail_lines()
+                )
+                if not details:
+                    details = [f"scenario errored with status: {status}"]
+                self.current_scenario_results["error"] = details
 
             if status == "skipped":
                 self.current_scenario_results["skipped"] = True
+
+    def _collect_hook_error_lines(self):
+        """
+        collect the error message lines captured by failing before/after
+        scenario hooks (see _run_hook in environment.py)
+        """
+        lines = []
+        for results_attr in ("before_hook_results", "after_hook_results"):
+            for hook_result in getattr(
+                self.current_scenario, results_attr, []
+            ):
+                if hook_result.get("status") == "error":
+                    lines += hook_result.get("error_message", [])
+        return lines
+
+    def _collect_detail_lines(self):
+        """
+        build the human readable detail lines for a failed/errored scenario:
+        custom failure handler output, the failing step, the exception, and
+        optionally the formatted stack trace
+        """
+        details = []
+        failure_handlers = CONFIG["__CUCU_CUSTOM_FAILURE_HANDLERS"]
+
+        for failure_handler in failure_handlers:
+            details.append(
+                failure_handler(self.current_feature, self.current_scenario)
+            )
+
+        if getattr(self, "current_step", None) is not None:
+            details += [
+                f"{self.current_step.keyword} {self.current_step.name} (after {round(self.current_step.duration, 3)}s)"
+            ]
+
+            if error := self.current_step.exception:
+                if isinstance(error, RetryError):
+                    error = error.last_attempt.exception()
+
+                if len(error.args) > 0 and isinstance(error.args[0], str):
+                    error_class_name = error.__class__.__name__
+                    error_lines = error.args[0].splitlines()
+                    error_lines[0] = f"{error_class_name}: {error_lines[0]}"
+                else:
+                    error_lines = [repr(error)]
+                details += error_lines
+
+        if (
+            CONFIG["CUCU_JUNIT_WITH_STACKTRACE"] == "true"
+            and self.current_scenario_traceback
+        ):
+            details += traceback.format_tb(self.current_scenario_traceback)
+
+        return details
 
     def scenario(self, scenario):
         self.update_scenario()
@@ -118,6 +152,7 @@ class CucuJUnitFormatter(Formatter):
             "status": "pending",
             "time": "n/a",
             "failure": None,
+            "error": None,
             "skipped": None,
         }
         self.current_scenario_results["foldername"] = escape(
@@ -290,6 +325,12 @@ class CucuJUnitFormatter(Formatter):
                 cleaned_failure_message = remove_ansi(failure_message)
                 failure.append(bs4.CData(cleaned_failure_message))
                 testcase.append(failure)
+
+            if scenario.get("error") is not None:
+                error_message = "\n".join(scenario["error"])
+                error = bs4.Tag(name="error")
+                error.append(bs4.CData(remove_ansi(error_message)))
+                testcase.append(error)
 
             if scenario["skipped"] is not None:
                 testcase.append(bs4.Tag(name="skipped"))

--- a/tests/test_junit_formatter.py
+++ b/tests/test_junit_formatter.py
@@ -1,0 +1,191 @@
+"""
+Tests for the cucu JUnit formatter, focused on the per-<testcase> child element
+that standard JUnit consumers use to classify results: <failure>, <error>,
+<skipped>, or none (passed).
+"""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+import pytest_check as check
+from behave.formatter.base import StreamOpener
+from behave.model_core import Status
+
+from cucu.config import CONFIG
+from cucu.formatter.junit import CucuJUnitFormatter
+
+
+class StubStatus:
+    """stand-in for the object returned by scenario.compute_status()"""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class StubFeature:
+    def __init__(self, name, tags=None):
+        self.name = name
+        self.tags = tags or []
+
+
+class StubScenario:
+    def __init__(
+        self,
+        name,
+        status="passed",
+        hook_failed=False,
+        tags=None,
+        before_hook_results=None,
+        after_hook_results=None,
+    ):
+        self.name = name
+        self._status = status
+        self.hook_failed = hook_failed
+        self.tags = tags or []
+        self.before_hook_results = before_hook_results or []
+        self.after_hook_results = after_hook_results or []
+
+    def compute_status(self):
+        return StubStatus(self._status)
+
+
+class StubStep:
+    def __init__(
+        self,
+        status,
+        duration=0.1,
+        keyword="When",
+        name="I do a thing",
+        exception=None,
+        exc_traceback=None,
+    ):
+        self.status = status
+        self.duration = duration
+        self.keyword = keyword
+        self.name = name
+        self.exception = exception
+        self.exc_traceback = exc_traceback
+
+
+@pytest.fixture
+def junit_env(tmp_path):
+    """
+    point the JUnit formatter at a temp dir and set the CONFIG keys it reads,
+    restoring the originals afterward
+    """
+    keys = {
+        "CUCU_JUNIT_DIR": str(tmp_path),
+        "CUCU_SHOW_SKIPS": "true",
+        "CUCU_JUNIT_WITH_STACKTRACE": "false",
+        "__CUCU_CUSTOM_FAILURE_HANDLERS": [],
+    }
+    originals = {key: CONFIG[key] for key in keys}
+    for key, value in keys.items():
+        CONFIG[key] = value
+
+    yield tmp_path
+
+    for key, value in originals.items():
+        CONFIG[key] = value
+
+
+def _run_feature(tmp_path, feature, scenario, step=None):
+    """
+    drive the formatter through a single scenario and return the parsed
+    <testsuite> element from the written XML
+    """
+    formatter = CucuJUnitFormatter(StreamOpener(filename="unused"), None)
+    formatter.feature(feature)
+    formatter.scenario(scenario)
+    if step is not None:
+        formatter.result(step)
+    formatter.eof()
+
+    output = (tmp_path / f"{feature.name}.xml").read_text()
+    return ET.fromstring(output)
+
+
+def test_passed_scenario_has_no_child_element(junit_env):
+    feature = StubFeature("passing feature")
+    scenario = StubScenario("a passing scenario", status="passed")
+    step = StubStep(Status.passed)
+
+    testsuite = _run_feature(junit_env, feature, scenario, step)
+    testcase = testsuite.find("testcase")
+
+    check.equal(testcase.get("status"), "passed")
+    check.is_none(testcase.find("failure"), "passed must not emit <failure>")
+    check.is_none(testcase.find("error"), "passed must not emit <error>")
+    check.is_none(testcase.find("skipped"), "passed must not emit <skipped>")
+    check.equal(testsuite.get("errors"), "0")
+    check.equal(testsuite.get("failures"), "0")
+
+
+def test_failed_scenario_emits_failure_only(junit_env):
+    feature = StubFeature("failing feature")
+    scenario = StubScenario("a failing scenario", status="failed")
+
+    try:
+        raise RuntimeError("assertion did not hold")
+    except RuntimeError as raised:
+        error = raised
+        traceback = raised.__traceback__
+
+    step = StubStep(Status.failed, exception=error, exc_traceback=traceback)
+
+    testsuite = _run_feature(junit_env, feature, scenario, step)
+    testcase = testsuite.find("testcase")
+
+    check.equal(testcase.get("status"), "failed")
+    check.is_not_none(testcase.find("failure"), "failed must emit <failure>")
+    check.is_none(testcase.find("error"), "failed must not emit <error>")
+    check.is_in("assertion did not hold", testcase.find("failure").text)
+    check.equal(testsuite.get("failures"), "1")
+    check.equal(testsuite.get("errors"), "0")
+
+
+def test_errored_scenario_emits_error_child(junit_env):
+    # model the real path: a before-scenario hook failure with no step run
+    feature = StubFeature("erroring feature")
+    hook_message = [
+        "HOOK-ERROR in before_scenario: ValueError: boom",
+        "Traceback (most recent call last):",
+        "  ...",
+    ]
+    scenario = StubScenario(
+        "an erroring scenario",
+        hook_failed=True,
+        before_hook_results=[
+            {"status": "error", "error_message": hook_message}
+        ],
+    )
+
+    testsuite = _run_feature(junit_env, feature, scenario, step=None)
+    testcase = testsuite.find("testcase")
+
+    check.equal(testcase.get("status"), "error")
+    error_element = testcase.find("error")
+    check.is_not_none(error_element, "errored scenario must emit <error>")
+    check.is_none(testcase.find("failure"), "errored must not emit <failure>")
+    if error_element is not None:
+        check.is_true(
+            error_element.text.strip(), "<error> must not be empty"
+        )
+        check.is_in("HOOK-ERROR in before_scenario", error_element.text)
+    check.equal(testsuite.get("errors"), "1")
+    check.equal(testsuite.get("failures"), "0")
+
+
+def test_skipped_scenario_emits_skipped_only(junit_env):
+    feature = StubFeature("skipping feature")
+    scenario = StubScenario("a skipped scenario", status="skipped")
+
+    testsuite = _run_feature(junit_env, feature, scenario, step=None)
+    testcase = testsuite.find("testcase")
+
+    check.equal(testcase.get("status"), "skipped")
+    check.is_not_none(testcase.find("skipped"), "skipped must emit <skipped>")
+    check.is_none(testcase.find("failure"), "skipped must not emit <failure>")
+    check.is_none(testcase.find("error"), "skipped must not emit <error>")
+    check.equal(testsuite.get("skipped"), "1")
+    check.equal(testsuite.get("errors"), "0")

--- a/tests/test_junit_formatter.py
+++ b/tests/test_junit_formatter.py
@@ -127,11 +127,10 @@ def test_failed_scenario_emits_failure_only(junit_env):
 
     try:
         raise RuntimeError("assertion did not hold")
-    except RuntimeError as raised:
-        error = raised
-        traceback = raised.__traceback__
-
-    step = StubStep(Status.failed, exception=error, exc_traceback=traceback)
+    except RuntimeError as error:
+        step = StubStep(
+            Status.failed, exception=error, exc_traceback=error.__traceback__
+        )
 
     testsuite = _run_feature(junit_env, feature, scenario, step)
     testcase = testsuite.find("testcase")
@@ -168,9 +167,7 @@ def test_errored_scenario_emits_error_child(junit_env):
     check.is_not_none(error_element, "errored scenario must emit <error>")
     check.is_none(testcase.find("failure"), "errored must not emit <failure>")
     if error_element is not None:
-        check.is_true(
-            error_element.text.strip(), "<error> must not be empty"
-        )
+        check.is_true(error_element.text.strip(), "<error> must not be empty")
         check.is_in("HOOK-ERROR in before_scenario", error_element.text)
     check.equal(testsuite.get("errors"), "1")
     check.equal(testsuite.get("failures"), "0")

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.26"
+version = "1.4.27"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://dominodatalab.atlassian.net/browse/QE-19421

## What is the new behavior?
JUnit formatter emits an `<error>` child element for errored scenarios (e.g. hook failures), so standard JUnit consumers (CircleCI, TestRail) classify them as errors instead of silently reporting them as passed

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
