### PR TITLE
QE-19314 Preserve fail status when after-hook errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.4.28
+- Fix - after-hook errors are no longer swallowed or allowed to corrupt status: a failing `after_step` hook keeps the step's own status (and still captures browser logs) instead of being reclassified by behave; `after_step` and `after_scenario` hook errors escalate the scenario to `error` only when no step actually failed (step-failure wins); `after_all` hooks always run cleanup (`CONFIG.restore`) and a hook error now aborts the run rather than being silently dropped
+
 # 1.4.27
 - Fix - JUnit formatter emits an `<error>` child element for errored scenarios (e.g. hook failures), so standard JUnit consumers (CircleCI, TestRail) classify them as errors instead of silently reporting them as passed
 

--- a/data/features/feature_with_mixed_results.feature
+++ b/data/features/feature_with_mixed_results.feature
@@ -14,9 +14,9 @@ Feature: Feature with mixed results
       And I echo "should never see this"   
 
   Scenario: Scenario with after-hook error
-    # Consider after-scenario errors outside of scenario status
+    # A passing scenario whose after-hook errors is reported as error
     Given I error after-scenario hook
-      And I echo "should see this as a pass"
+      And I echo "should see this scenario reported as an error"
 
   Scenario: Scenario that also passes
     Given I echo "passing"

--- a/features/cli/report_basics.feature
+++ b/features/cli/report_basics.feature
@@ -106,7 +106,7 @@ Feature: Report basics
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
         | Start at | Features.*                 | Scenarios.* | Passed.* | Failed.* | Skipped.* | Error.* | Status | Duration.* |
-        | .*       | Feature with mixed results | 6           | 3        | 3        | 0         | 0         | failed | .*         |
+        | .*       | Feature with mixed results | 6           | 2        | 3        | 0         | 1         | failed | .*         |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
         | Offset | Scenario                            | Steps | Status  | Duration |
@@ -115,7 +115,7 @@ Feature: Report basics
         | .*     | Scenario that fails                 | 2     | failed  | .*       |
         | .*     | Scenario that has an undefined step | 1     | failed  | .*       |
         | .*     | Scenario that passes                | 1     | passed  | .*       |
-        | .*     | Scenario with after-hook error      | 2     | passed  | .*       |
+        | .*     | Scenario with after-hook error      | 2     | error   | .*       |
       And I click the button "Scenario that fails"
       And I click the button "I fail"
      Then I should see the text "ASSERT FAILED: step fails on purpose"
@@ -132,7 +132,7 @@ Feature: Report basics
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
         | Start at | Features.*                 | Scenarios.* | Passed.* | Failed.* | Skipped.* | Error.* | Status | Duration.* |
-        | .*       | Feature with mixed results | 7           | 3        | 3        | 1         | 0         | failed | .*         |
+        | .*       | Feature with mixed results | 7           | 2        | 3        | 1         | 1         | failed | .*         |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
         | Offset | Scenario                            | Steps | Status  | Duration |
@@ -142,7 +142,7 @@ Feature: Report basics
         | .*     | Scenario that has an undefined step | 1     | failed  | .*       |
         | .*     | Scenario that is skipped            | 1     | skipped | .*       |
         | .*     | Scenario that passes                | 1     | passed  | .*       |
-        | .*     | Scenario with after-hook error      | 2     | passed  | .*       |
+        | .*     | Scenario with after-hook error      | 2     | error   | .*       |
 
       And I click the button "Scenario that fails"
       And I click the button "I fail"
@@ -267,7 +267,7 @@ Feature: Report basics
       And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/index.html"
      Then I should see a table that matches the following:
         | Start at | Features.*                 | Scenarios.* | Passed.* | Failed.* | Skipped.* | Error.* | Status | Duration.* |
-        | .*       | Feature with mixed results | 6           | 3        | 3        | 0         | 0         | failed | .*         |
+        | .*       | Feature with mixed results | 6           | 2        | 3        | 0         | 1         | failed | .*         |
      When I click the button "Feature with mixed results"
      Then I should see a table that matches the following:
         | Offset | Scenario                            | Steps | Status  | Duration |
@@ -276,7 +276,7 @@ Feature: Report basics
         | .*     | Scenario that fails                 | 2     | failed  | .*       |
         | .*     | Scenario that has an undefined step | 1     | failed  | .*       |
         | .*     | Scenario that passes                | 1     | passed  | .*       |
-        | .*     | Scenario with after-hook error      | 2     | passed  | .*       |
+        | .*     | Scenario with after-hook error      | 2     | error   | .*       |
       And I click the button "Scenario that fails"
       And I click the button "I fail"
      Then I should see the text "ASSERT FAILED: step fails on purpose"

--- a/features/cli/run_outputs.feature
+++ b/features/cli/run_outputs.feature
@@ -144,7 +144,7 @@ Feature: Run outputs
      Then I should see a file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/Feature with mixed results.xml"
       And I should see the file at "{CUCU_RESULTS_DIR}/validate_junit_xml_results/Feature with mixed results.xml" matches the following:
       """
-      <testsuite name="Feature with mixed results" foldername="Feature with mixed results" tests="7" errors="0" failures="3" skipped="1" timestamp=".*" tags="mixed">
+      <testsuite name="Feature with mixed results" foldername="Feature with mixed results" tests="7" errors="1" failures="3" skipped="1" timestamp=".*" tags="mixed">
        <testcase classname="Feature with mixed results" name="Scenario that passes" foldername="Scenario that passes" status="passed" time=".*">
        </testcase>
        <testcase classname="Feature with mixed results" name="Scenario that fails" foldername="Scenario that fails" status="failed" time=".*">
@@ -157,7 +157,10 @@ Feature: Run outputs
         [\s\S]*
         </failure>
        </testcase>
-       <testcase classname="Feature with mixed results" name="Scenario with after-hook error" foldername="Scenario with after-hook error" status="passed" time=".*">
+       <testcase classname="Feature with mixed results" name="Scenario with after-hook error" foldername="Scenario with after-hook error" status="error" time=".*">
+        <error>
+        [\s\S]*
+        </error>
        </testcase>
        <testcase classname="Feature with mixed results" name="Scenario that also passes" foldername="Scenario that also passes" status="passed" time=".*">
        </testcase>

--- a/features/cli/run_with_hooks.feature
+++ b/features/cli/run_with_hooks.feature
@@ -172,7 +172,7 @@ Feature: Run with hooks
         Scenario: Hello world scenario
           Given I echo "Hello World"
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/failing_custom_hooks/echo.feature --results {CUCU_RESULTS_DIR}/failing_custom_hooks_results/ -l debug --no-color-output --generate-report --report {CUCU_RESULTS_DIR}/failing_custom_hooks_report/" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/failing_custom_hooks/echo.feature --results {CUCU_RESULTS_DIR}/failing_custom_hooks_results/ -l debug --no-color-output --generate-report --report {CUCU_RESULTS_DIR}/failing_custom_hooks_report/" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
      Then I should see "{STDOUT}" contains the following
       """
       HOOK-ERROR in after_scenario_fail: AssertionError: boom
@@ -248,7 +248,7 @@ Feature: Run with hooks
         Scenario: Hello world scenario
           Given I echo "Hello World"
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/mixed_results_fail_pass_hooks/echo.feature --results {CUCU_RESULTS_DIR}/mixed_results_fail_pass_hooks_results/ -l debug --no-color-output --generate-report --report {CUCU_RESULTS_DIR}/mixed_results_fail_pass_hooks_report/" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/mixed_results_fail_pass_hooks/echo.feature --results {CUCU_RESULTS_DIR}/mixed_results_fail_pass_hooks_results/ -l debug --no-color-output --generate-report --report {CUCU_RESULTS_DIR}/mixed_results_fail_pass_hooks_report/" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
      Then I should see "{STDOUT}" contains the following
       """
       HOOK-ERROR in after_scenario_fail: AssertionError: boom
@@ -295,7 +295,7 @@ Feature: Run with hooks
         Scenario: Hello world scenario
           Given I echo "Hello World"
       """
-     When I run the command "cucu run {CUCU_RESULTS_DIR}/mixed_results_pass_fail_hooks/echo.feature --results {CUCU_RESULTS_DIR}/mixed_results_pass_fail_hooks_results/ -l debug --no-color-output --generate-report --report {CUCU_RESULTS_DIR}/mixed_results_pass_fail_hooks_report/" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "0"
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/mixed_results_pass_fail_hooks/echo.feature --results {CUCU_RESULTS_DIR}/mixed_results_pass_fail_hooks_results/ -l debug --no-color-output --generate-report --report {CUCU_RESULTS_DIR}/mixed_results_pass_fail_hooks_report/" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
      Then I should see "{STDOUT}" contains the following
       """
       HOOK-ERROR in after_scenario_fail: AssertionError: boom
@@ -350,3 +350,101 @@ Feature: Run with hooks
      # When I wait to click the link "Logs"
      #  And I wait to click the link "cucu.debug.console.log"
      # Then I wait to see the text "This error should be logged and reported."
+
+  Scenario: When an after_step hook fails on a passing step, the Scenario reports as error
+    Given I create a file at "{CUCU_RESULTS_DIR}/failing_after_step_pass/environment.py" with the following:
+      """
+      from cucu.environment import *
+      from cucu import register_after_step_hook
+
+      def after_step_fail(ctx):
+          raise AssertionError("boom")
+
+      register_after_step_hook(after_step_fail)
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/failing_after_step_pass/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/failing_after_step_pass/echo.feature" with the following:
+      """
+      Feature: Feature with a passing step and a failing after_step hook
+
+        Scenario: Hello world scenario
+          Given I echo "Hello World"
+      """
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/failing_after_step_pass/echo.feature --results {CUCU_RESULTS_DIR}/failing_after_step_pass_results/ -l debug --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+     Then I should see "{STDOUT}" contains the following
+      """
+      HOOK-ERROR in after_step_fail: AssertionError: boom
+      """
+     When I run the command "cucu report {CUCU_RESULTS_DIR}/failing_after_step_pass_results --output {CUCU_RESULTS_DIR}/failing_after_step_pass_report" and expect exit code "0"
+      And I start a webserver at directory "{CUCU_RESULTS_DIR}/failing_after_step_pass_report/" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/flat.html"
+     Then I should see a table that contains rows matching the following
+        | .* | Feature with a passing step and a failing after_step hook | Hello world scenario | .* | error | .* |
+
+  Scenario: When an after_step hook fails on a failing step, the Scenario still reports as failed
+    Given I create a file at "{CUCU_RESULTS_DIR}/failing_after_step_fail/environment.py" with the following:
+      """
+      from cucu.environment import *
+      from cucu import register_after_step_hook
+
+      def after_step_fail(ctx):
+          raise AssertionError("boom")
+
+      register_after_step_hook(after_step_fail)
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/failing_after_step_fail/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/failing_after_step_fail/echo.feature" with the following:
+      """
+      Feature: Feature with a failing step and a failing after_step hook
+
+        Scenario: Failing scenario
+          Then I should see "Hello" is equal to "Goodbye"
+      """
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/failing_after_step_fail/echo.feature --results {CUCU_RESULTS_DIR}/failing_after_step_fail_results/ -l debug --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+     Then I should see "{STDOUT}" contains the following
+      """
+      HOOK-ERROR in after_step_fail: AssertionError: boom
+      """
+     When I run the command "cucu report {CUCU_RESULTS_DIR}/failing_after_step_fail_results --output {CUCU_RESULTS_DIR}/failing_after_step_fail_report" and expect exit code "0"
+      And I start a webserver at directory "{CUCU_RESULTS_DIR}/failing_after_step_fail_report/" and save the port to the variable "PORT"
+      And I open a browser at the url "http://{HOST_ADDRESS}:{PORT}/flat.html"
+     Then I should see a table that contains rows matching the following
+        | .* | Feature with a failing step and a failing after_step hook | Failing scenario | .* | failed | .* |
+
+  Scenario: When an after_all hook fails, cleanup still runs and the run is marked failing
+    Given I create a file at "{CUCU_RESULTS_DIR}/failing_after_all/environment.py" with the following:
+      """
+      from cucu.environment import *
+      from cucu import register_after_all_hook
+
+      def after_all_fail(ctx):
+          raise AssertionError("boom")
+
+      register_after_all_hook(after_all_fail)
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/failing_after_all/steps/__init__.py" with the following:
+      """
+      from cucu.steps import *
+      """
+      And I create a file at "{CUCU_RESULTS_DIR}/failing_after_all/echo.feature" with the following:
+      """
+      Feature: Feature with a passing scenario and a failing after_all hook
+
+        Scenario: Hello world scenario
+          Given I echo "Hello World"
+      """
+     When I run the command "cucu run {CUCU_RESULTS_DIR}/failing_after_all/echo.feature --results {CUCU_RESULTS_DIR}/failing_after_all_results/ -l debug --no-color-output" and save stdout to "STDOUT", stderr to "STDERR" and expect exit code "1"
+     Then I should see "{STDOUT}" contains the following
+      """
+      HOOK-ERROR in after_all_fail: AssertionError: boom
+      """
+      And I should see "{STDOUT}" contains the following
+      """
+      1 scenario passed, 0 failed, 0 skipped
+      """

--- a/features/cli/run_with_hooks.feature
+++ b/features/cli/run_with_hooks.feature
@@ -65,11 +65,13 @@ Feature: Run with hooks
       Hello
 
       .* DEBUG just logging some stuff from my after step hook
+      .* DEBUG HOOK after_step_log: passed ✅
           Given I echo "Hello" \s*# .*
       .* DEBUG just logging some stuff from my before step hook
       World
 
       .* DEBUG just logging some stuff from my after step hook
+      .* DEBUG HOOK after_step_log: passed ✅
             And I echo "World" \s*# .*
       .* DEBUG No browser found, skipping keep-alive
       .* DEBUG HOOK start_selenium_keep_alive: passed ✅

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.27"
+version = "1.4.28"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/environment.py
+++ b/src/cucu/environment.py
@@ -58,9 +58,16 @@ def before_all(ctx):
 
 
 def after_all(ctx):
-    # run the after all hooks
+    # run the after all hooks; wrap each so a raising hook never skips cleanup
+    hook_errored = False
     for hook in CONFIG["__CUCU_AFTER_ALL_HOOKS"]:
-        hook(ctx)
+        if _run_hook(ctx, hook)["status"] == "error":
+            hook_errored = True
+
+    # signal the run as aborted (same mechanism as runtime timeout) so a hook
+    # error at the run tier surfaces as a failure rather than being swallowed
+    if hook_errored:
+        ctx._runner.aborted = True
 
     CONFIG.restore(with_pop=True)
 
@@ -207,11 +214,17 @@ def after_scenario(ctx, scenario):
 
     # run after all scenario hooks in 'lifo' order.
     for hook in CONFIG["__CUCU_AFTER_SCENARIO_HOOKS"][::-1]:
-        scenario.after_hook_results.append(_run_hook(ctx, hook))
+        hook_result = _run_hook(ctx, hook)
+        if hook_result["status"] == "error":
+            scenario.hook_failed = True
+        scenario.after_hook_results.append(hook_result)
 
     # run after this scenario hooks in 'lifo' order.
     for hook in CONFIG["__CUCU_AFTER_THIS_SCENARIO_HOOKS"][::-1]:
-        scenario.after_hook_results.append(_run_hook(ctx, hook))
+        hook_result = _run_hook(ctx, hook)
+        if hook_result["status"] == "error":
+            scenario.hook_failed = True
+        scenario.after_hook_results.append(hook_result)
 
     CONFIG["__CUCU_AFTER_THIS_SCENARIO_HOOKS"] = []
 
@@ -235,6 +248,15 @@ def after_scenario(ctx, scenario):
     )
 
     scenario.end_at = get_iso_timestamp_with_ms()
+
+    # step-failure wins over a hook error: if a step actually failed, the
+    # scenario already has its own failure signal, so don't let an after-hook
+    # error (from after_step or after_scenario) reclassify it as 'error'.
+    if scenario.hook_failed and any(
+        step.status.is_failure() or step.status.is_error()
+        for step in scenario.all_steps
+    ):
+        scenario.hook_failed = False
 
 
 def download_mht_data(ctx):
@@ -369,9 +391,13 @@ def after_step(ctx, step):
 
     CONFIG["__CUCU_BEFORE_THIS_SCENARIO_HOOKS"] = []
 
-    # run after all step hooks
+    # run after all step hooks; wrap each so a raising hook neither skips the
+    # browser-log capture below nor lets behave reclassify the step's status.
+    # An errored hook escalates the scenario to 'error' via hook_failed unless a
+    # step actually failed (resolved at the end of after_scenario).
     for hook in CONFIG["__CUCU_AFTER_STEP_HOOKS"]:
-        hook(ctx)
+        if _run_hook(ctx, hook)["status"] == "error":
+            ctx.scenario.hook_failed = True
 
     # Capture browser logs and info for this step
     step.browser_logs = []

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.27"
+version = "1.4.28"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
QE-19314 Preserve fail status when after-hook errors

- Wrap after-hook execution in all three tiers (after_all, after_scenario, after_step) so hook exceptions are caught and don't corrupt status or skip cleanup
- Set `scenario.hook_failed` when a hook errors, escalating the scenario to `error` only when no step actually failed (step-failure wins)
- For `after_all` hooks: ensure cleanup (`CONFIG.restore`) always runs, then set `ctx._runner.aborted = True` if any hook errored (aborting the run rather than silently dropping the error)
- Add comprehensive test coverage for after_step hook errors on both passing and failing steps, and for after_all hook errors during cleanup

## Other changes
- Update three existing after_scenario hook error tests (lines 152, 223, 270 in `run_with_hooks.feature`) to expect exit code 1 and `error` status, now that hook errors properly escalate when no step failed
- Update test output expectations for after_step hook logging to reflect the new `HOOK after_step_log: passed` debug line

## Info
Ticket: https://dominodatalab.atlassian.net/browse/QE-19314

## Testing
- [x] `uv run cucu run features/cli/run_with_hooks.feature` — all scenarios including three new after_step/after_all hook error cases
- [x] `uv run pytest tests/` — unit test suite passes
- [x] Manual verification of the status matrix: failed step + errored hook → failed (not error), passed step + errored hook → error, after_all hook error → aborts run

## For reviewers

This change fixes a class of status corruption bugs where after-hook exceptions would cause a step to be reclassified from `failed` to `error`, or cause a hook error to be silently swallowed. The fix reuses the existing `scenario.hook_failed` attribute (already honored by formatters to render as `error`) and adds a resolution block at the end of `after_scenario` that implements the principle: **a failure observed at the tier wins over a hook error**.

The implementation touches three hook-execution paths in `src/cucu/environment.py` to wrap each with the `_run_hook` helper. The `after_all` path also sets `ctx._runner.aborted = True` (same mechanism as runtime timeout) to surface a run-tier hook error as a failure. Tests are comprehensive: three new scenarios exercise the load-bearing path (after_step error on failing step), plus after_step error on a passing step (escalates to error), plus after_all error during cleanup (aborts the run). Three existing after_scenario hook error tests are updated to expect the correct exit code (1 instead of 0) now that their scenarios properly escalate to error when no step failed.

Suggested review order:
1. `src/cucu/environment.py` — the three hook-execution wrappers and the resolution block
2. `features/cli/run_with_hooks.feature` — the three new test scenarios and the three updated assertions
3. Version bump in `pyproject.toml` and changelog entry
