### PR TITLE
Ddl kavya qe 19441 disable caseless substring fuzzy match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project closely adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 1.4.29
+- Fix - `nameInNestedChild` passes the inner element's immediate text as `immediate_override` so the clickable ancestor is scored on the clean title text, not the concatenated descendant text (e.g. badge counts)
+- Fix - removed caseless substring scoring from `cucu.relevance` to prevent short queries (e.g. `"R"`) from false-positive matching unrelated labels (e.g. `"Govern"`); caseless exact matching is preserved
+
 # 1.4.28
 - Fix - after-hook errors are no longer swallowed or allowed to corrupt status: a failing `after_step` hook keeps the step's own status (and still captures browser logs) instead of being reclassified by behave; `after_step` and `after_scenario` hook errors escalate the scenario to `error` only when no step actually failed (step-failure wins); `after_all` hooks always run cleanup (`CONFIG.restore`) and a hook error now aborts the run rather than being silently dropped
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cucu"
-version = "1.4.28"
+version = "1.4.29"
 description = "Easy BDD web testing"
 readme = "README.md"
 license = "BSD-3-Clause-Clear"

--- a/src/cucu/fuzzy/fuzzy.js
+++ b/src/cucu/fuzzy/fuzzy.js
@@ -384,9 +384,14 @@
                 var thing = things[tIndex];
 
                 var nameInNestedChildLabel = `<${thing}><*>...${name}...</*></${thing}>`;
-                results = jqRoots('*:vis:' + matcher + '("' + name + '")').parents(thing).toArray();
-                if (cucu.debug) { console.log(nameInNestedChildLabel, results); }
-                elements = elements.concat(results.map(x => ({element: x, label: nameInNestedChildLabel, label_name: 'nameInNestedChild'})));
+                var innerMatches = jqRoots('*:vis:' + matcher + '("' + name + '")').toArray();
+                for (var iIndex = 0; iIndex < innerMatches.length; iIndex++) {
+                    var innerEl = innerMatches[iIndex];
+                    var innerImm = getImmediateText(innerEl);
+                    var ancestors = jqCucu(innerEl).parents(thing).toArray();
+                    if (cucu.debug) { console.log(nameInNestedChildLabel, ancestors); }
+                    elements = elements.concat(ancestors.map(x => ({element: x, label: nameInNestedChildLabel, label_name: 'nameInNestedChild', immediate_override: innerImm})));
+                }
 
                 for(var aIndex=0; aIndex < attributes.length; aIndex++) {
                     var attribute_name = attributes[aIndex];

--- a/src/cucu/fuzzy/fuzzy.js
+++ b/src/cucu/fuzzy/fuzzy.js
@@ -72,8 +72,7 @@
         match: {
             exact: 205,
             caselessexact: 200,
-            substring: 55,
-            caselesssubstring: 50
+            substring: 55
         },
         attrSub: {
             'aria-label': 34,
@@ -140,9 +139,6 @@
         } else if (includes(imm, query)) {
             best = Math.max(best, WEIGHTS.area.immediate + WEIGHTS.match.substring);
             higherPriorityMatchFound = true;
-        } else if (includesCi(imm, query)) {
-            best = Math.max(best, WEIGHTS.area.immediate + WEIGHTS.match.caselesssubstring);
-            higherPriorityMatchFound = true;
         }
 
         var attrNames = ['aria-label', 'id', 'class', 'title', 'placeholder', 'value'];
@@ -160,9 +156,6 @@
             } else if (includes(av, query)) {
                 best = Math.max(best, WEIGHTS.area.attribute + WEIGHTS.match.substring + sub);
                 higherPriorityMatchFound = true;
-            } else if (av.toLowerCase().indexOf(query.toLowerCase()) !== -1) {
-                best = Math.max(best, WEIGHTS.area.attribute + WEIGHTS.match.caselesssubstring + sub);
-                higherPriorityMatchFound = true;
             }
         }
 
@@ -178,8 +171,6 @@
         } else if (includes(ft, query)) {
             // Substring matches never get promoted
             best = Math.max(best, WEIGHTS.area.fulltext + WEIGHTS.match.substring);
-        } else if (includesCi(ft, query)) {
-            best = Math.max(best, WEIGHTS.area.fulltext + WEIGHTS.match.caselesssubstring);
         }
 
         if (best === 0 && ft.length === 0) {

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "cucu"
-version = "1.4.28"
+version = "1.4.29"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://dominodatalab.atlassian.net/browse/QE-19441

## What is the new behavior?
- Fix - `nameInNestedChild` passes the inner element's immediate text as `immediate_override` so the clickable ancestor is scored on the clean title text, not the concatenated descendant text (e.g. badge counts)
- Fix - removed caseless substring scoring from `cucu.relevance` to prevent short queries (e.g. `"R"`) from false-positive matching unrelated labels (e.g. `"Govern"`); caseless exact matching is preserved

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
